### PR TITLE
Upgrade amplify packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,14 +8,14 @@
       "name": "amplify-vite-react-template",
       "version": "0.0.0",
       "dependencies": {
-        "@aws-amplify/ui-react": "^6.2.0",
-        "aws-amplify": "^6.5.2",
+        "@aws-amplify/ui-react": "^6.5.5",
+        "aws-amplify": "^6.6.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
-        "@aws-amplify/backend": "^1.1.1",
-        "@aws-amplify/backend-cli": "^1.2.4",
+        "@aws-amplify/backend": "^1.5.0",
+        "@aws-amplify/backend-cli": "^1.2.9",
         "@types/react": "^18.2.66",
         "@types/react-dom": "^18.2.22",
         "@typescript-eslint/eslint-plugin": "^7.2.0",
@@ -30,7 +30,7 @@
         "eslint-plugin-react-refresh": "^0.4.6",
         "tsx": "^4.7.2",
         "typescript": "^5.4.5",
-        "vite": "^5.2.0"
+        "vite": "^5.4.10"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -96,29 +96,28 @@
       }
     },
     "node_modules/@ardatan/relay-compiler/node_modules/@babel/generator": {
-      "version": "7.25.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.5.tgz",
-      "integrity": "sha512-abd43wyLfbWoxC6ahM8xTkqLpGB2iWBVyuKC9/srhFunCd1SDNrV1s72bBpK4hLj8KLzHBBcOblvLQZBNw9r3w==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.9.tgz",
+      "integrity": "sha512-omlUGkr5EaoIJrhLf9CJ0TvjBRpd9+AXRG//0GEQ9THSo8wPiTlbpy1/Ow8ZTrbXpjd9FHXfbFQx32I04ht0FA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.25.4",
+        "@babel/types": "^7.25.9",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
-        "jsesc": "^2.5.1"
+        "jsesc": "^3.0.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@ardatan/relay-compiler/node_modules/@babel/types": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.4.tgz",
-      "integrity": "sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.9.tgz",
+      "integrity": "sha512-OwS2CM5KocvQ/k7dFJa8i5bNGJP0hXWfVCfDkqRFP1IreH1JDC7wG6eCYCi0+McbfT8OR/kNqsI0UU0xP9H6PQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -199,6 +198,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@ardatan/relay-compiler/node_modules/jsesc": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@ardatan/relay-compiler/node_modules/locate-path": {
@@ -340,9 +351,9 @@
       }
     },
     "node_modules/@aws-amplify/analytics": {
-      "version": "7.0.44",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-7.0.44.tgz",
-      "integrity": "sha512-P+AFKisNzadCzrKq58Cbo21JpcEiEvHg+EiE+PNdm2J5yVxS+k/zDLWb42CyzVEOXdekG0dqYKQqLLiFR2gMFg==",
+      "version": "7.0.53",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-7.0.53.tgz",
+      "integrity": "sha512-VNbE1foPeQxKFZ2Svcfu61U+jYrsIBR1+VFF2inUqMxG6MudID/qcOZQALfA1kbLVfk79C4fA2KxhVSvnTAr2w==",
       "dependencies": {
         "@aws-sdk/client-firehose": "3.621.0",
         "@aws-sdk/client-kinesis": "3.621.0",
@@ -390,23 +401,23 @@
       }
     },
     "node_modules/@aws-amplify/api": {
-      "version": "6.0.46",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-6.0.46.tgz",
-      "integrity": "sha512-OL3wdTuhELtVbbTyyIGOYI3z2X7DFYMIWfgr4m8M/Sm6tj4rMRzQeoeeLRIcfBRICzdwQdxVCoOJmHR6nrJMmQ==",
+      "version": "6.0.55",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-6.0.55.tgz",
+      "integrity": "sha512-mKAGv6ciqETRmVmgM4PNzZU1uZuzHwMuhjUJ+fOqQECN6qexnAV3jE8CPJv/Uiz7Oi9IhvYdkLRroYDOKarU/A==",
       "dependencies": {
-        "@aws-amplify/api-graphql": "4.1.15",
-        "@aws-amplify/api-rest": "4.0.44",
+        "@aws-amplify/api-graphql": "4.4.2",
+        "@aws-amplify/api-rest": "4.0.53",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-amplify/api-graphql": {
-      "version": "4.1.15",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-4.1.15.tgz",
-      "integrity": "sha512-4LJBXDu4SJwZf5CBvmfDq7LUgmFJpWWVf0dC8jTpcHR8Dr4ajFP2HgefqqHJn+WFlZDAFcYHxl0pWEZYp/jybg==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-4.4.2.tgz",
+      "integrity": "sha512-5h4bqKJ2+w0kwIqgiq5xe3S71Lksg6vkDZjmAXzLIpSZpLHN11O8Fd4sR7fPAbOFx0eea0OvZYjRQcOhoxHOow==",
       "dependencies": {
-        "@aws-amplify/api-rest": "4.0.44",
-        "@aws-amplify/core": "6.3.11",
-        "@aws-amplify/data-schema": "^1.0.0",
+        "@aws-amplify/api-rest": "4.0.53",
+        "@aws-amplify/core": "6.4.6",
+        "@aws-amplify/data-schema": "^1.7.0",
         "@aws-sdk/types": "3.387.0",
         "graphql": "15.8.0",
         "rxjs": "^7.8.1",
@@ -438,9 +449,9 @@
       }
     },
     "node_modules/@aws-amplify/api-rest": {
-      "version": "4.0.44",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-4.0.44.tgz",
-      "integrity": "sha512-3kVDthcHQ2+SOm4D64irT3CMRebpDzKxxgH/sG4IoAipSU+6Mcpz2Pb0a2JIinEZhbZNEi78/omRWcDEYwPNiQ==",
+      "version": "4.0.53",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-4.0.53.tgz",
+      "integrity": "sha512-WhGl/kcMFO+QSvoiM5+QCtrPM3YGFzNijV8BwVwy4KhTGnGx1qXgzkYjfHm2/nucL4GlNQE/tVWAK+Sxl+EFHQ==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -449,9 +460,9 @@
       }
     },
     "node_modules/@aws-amplify/appsync-modelgen-plugin": {
-      "version": "2.12.3",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/appsync-modelgen-plugin/-/appsync-modelgen-plugin-2.12.3.tgz",
-      "integrity": "sha512-w52qvu5AFWrzLOGAmfyEaxAyxBdfEPOFy3nwBavcO6GWhTtgz5dd1leuUgMBlXDlvfzrozxTrkits2Tnu4YWpg==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/appsync-modelgen-plugin/-/appsync-modelgen-plugin-2.13.2.tgz",
+      "integrity": "sha512-gJrOHUnjSCevCNCfFinSB1fHDaOgWIjo+HDj68rcDlYBJz3S43R7yUFy5O3Lv6mQ5EbgNjUCNJ6rPLjMPuzaXw==",
       "dev": true,
       "dependencies": {
         "@graphql-codegen/plugin-helpers": "^1.18.8",
@@ -470,9 +481,9 @@
       }
     },
     "node_modules/@aws-amplify/auth": {
-      "version": "6.3.15",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-6.3.15.tgz",
-      "integrity": "sha512-zS+iuQsZoOPl2QeQFBerBmizorwbxp/DV6neah8eztxC9MS7kztM+J5TaIJweR/+Vf3zKZJBCqnGcqXKUEyUrw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-6.5.3.tgz",
+      "integrity": "sha512-wy1CmwxZlLGAnxPcnhVY4vlzirjTJoF8aBBqC9IuRIAQW+NuOAIBc4kRhmnPGauTVbmztaS4USRpKkqxkADcsA==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -481,14 +492,14 @@
       }
     },
     "node_modules/@aws-amplify/auth-construct": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/auth-construct/-/auth-construct-1.3.0.tgz",
-      "integrity": "sha512-scOk6Q5VhMwrSDSTF4V/HKKUGyOVni0a3MERkre4n2IYZXCrt0b4iFmOEHul7is6aNDPp3TVs0sJ70j6HwVu8g==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/auth-construct/-/auth-construct-1.3.1.tgz",
+      "integrity": "sha512-1i2f5Wkv1fq4Eieb1UOaZfjchPAsExJxSZBOP89GnS2TU/PCceibZAFBUKUZ9FMqwItyxms/3fHUPHaBVlVqSA==",
       "dev": true,
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
-        "@aws-amplify/backend-output-storage": "^1.1.1",
-        "@aws-amplify/plugin-types": "^1.2.1",
+        "@aws-amplify/backend-output-storage": "^1.1.2",
+        "@aws-amplify/plugin-types": "^1.2.2",
         "@aws-sdk/util-arn-parser": "^3.568.0"
       },
       "peerDependencies": {
@@ -497,22 +508,22 @@
       }
     },
     "node_modules/@aws-amplify/backend": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/backend/-/backend-1.1.1.tgz",
-      "integrity": "sha512-r4SLG54AKUCDOc/pYUqliDyFGCdrsFAmh3SH8Jp92Hzri+LCOOr8WazN1py9NWfydWmT2GbP1r910edbosDy4g==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/backend/-/backend-1.5.0.tgz",
+      "integrity": "sha512-eZpMy1iYL1xP4eofSvAQ5YejJLm+Z8rLqQrw+VH0E3DckQcN6+qAsn7XSRfYxQoJRJhDWsw1TkU+MzWYvNfb2Q==",
       "dev": true,
       "dependencies": {
-        "@aws-amplify/backend-auth": "^1.1.2",
-        "@aws-amplify/backend-data": "^1.1.1",
-        "@aws-amplify/backend-function": "^1.3.2",
-        "@aws-amplify/backend-output-schemas": "^1.2.0",
-        "@aws-amplify/backend-output-storage": "^1.1.1",
-        "@aws-amplify/backend-secret": "^1.0.1",
-        "@aws-amplify/backend-storage": "^1.1.1",
-        "@aws-amplify/client-config": "^1.2.0",
+        "@aws-amplify/backend-auth": "^1.2.0",
+        "@aws-amplify/backend-data": "^1.1.4",
+        "@aws-amplify/backend-function": "^1.7.0",
+        "@aws-amplify/backend-output-schemas": "^1.3.0",
+        "@aws-amplify/backend-output-storage": "^1.1.2",
+        "@aws-amplify/backend-secret": "^1.1.4",
+        "@aws-amplify/backend-storage": "^1.2.1",
+        "@aws-amplify/client-config": "^1.4.0",
         "@aws-amplify/data-schema": "^1.0.0",
-        "@aws-amplify/platform-core": "^1.0.6",
-        "@aws-amplify/plugin-types": "^1.2.1",
+        "@aws-amplify/platform-core": "^1.1.0",
+        "@aws-amplify/plugin-types": "^1.3.0",
         "@aws-sdk/client-amplify": "^3.624.0",
         "lodash.snakecase": "^4.1.1"
       },
@@ -522,14 +533,14 @@
       }
     },
     "node_modules/@aws-amplify/backend-auth": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-auth/-/backend-auth-1.1.3.tgz",
-      "integrity": "sha512-ur1nED2nCtcC9527iNhgGvZD2bAjH8/B1UWguFhUQuEFtrWnVlMdR/4/9csmdr7KWCSAp4f4GMIZaGnCyw2Ofg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-auth/-/backend-auth-1.2.0.tgz",
+      "integrity": "sha512-v1FYzq/NPuAlsGhUjNB+EdzxqcD3/MZKUlo+NC0kx++M0Bxt5V/I51ws7NL8EiB0nTr7GzZKl3fqK30vgJCJ9g==",
       "dev": true,
       "dependencies": {
-        "@aws-amplify/auth-construct": "^1.3.0",
-        "@aws-amplify/backend-output-storage": "^1.1.1",
-        "@aws-amplify/plugin-types": "^1.2.1"
+        "@aws-amplify/auth-construct": "^1.3.1",
+        "@aws-amplify/backend-output-storage": "^1.1.2",
+        "@aws-amplify/plugin-types": "^1.3.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.152.0",
@@ -537,22 +548,23 @@
       }
     },
     "node_modules/@aws-amplify/backend-cli": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-cli/-/backend-cli-1.2.5.tgz",
-      "integrity": "sha512-0OPQfRFClH5iU4Bud8BR6364vW2jZLTUsaqivyAD0o4bmHE8B3H+DNi9X+ayNgys+i/y3x/uouqhT8Napo2aow==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-cli/-/backend-cli-1.2.9.tgz",
+      "integrity": "sha512-MgNRPXkaF/ZY1lovYy7XXcY3NFA5MHj54L9J4iE2KVsHfXwahqCb82ZEYxj+WnIYH6Vb6af/Fj6L68EE81Gqlg==",
       "dev": true,
       "dependencies": {
-        "@aws-amplify/backend-deployer": "^1.1.0",
-        "@aws-amplify/backend-output-schemas": "^1.1.0",
-        "@aws-amplify/backend-secret": "^1.1.0",
-        "@aws-amplify/cli-core": "^1.1.2",
-        "@aws-amplify/client-config": "^1.2.1",
-        "@aws-amplify/deployed-backend-client": "^1.3.0",
-        "@aws-amplify/form-generator": "^1.0.1",
-        "@aws-amplify/model-generator": "^1.0.5",
+        "@aws-amplify/backend-deployer": "^1.1.3",
+        "@aws-amplify/backend-output-schemas": "^1.2.1",
+        "@aws-amplify/backend-secret": "^1.1.2",
+        "@aws-amplify/cli-core": "^1.1.3",
+        "@aws-amplify/client-config": "^1.4.0",
+        "@aws-amplify/deployed-backend-client": "^1.4.1",
+        "@aws-amplify/form-generator": "^1.0.3",
+        "@aws-amplify/model-generator": "^1.0.8",
         "@aws-amplify/platform-core": "^1.0.5",
-        "@aws-amplify/sandbox": "^1.2.0",
-        "@aws-amplify/schema-generator": "^1.2.1",
+        "@aws-amplify/plugin-types": "^1.3.0",
+        "@aws-amplify/sandbox": "^1.2.2",
+        "@aws-amplify/schema-generator": "^1.2.4",
         "@aws-sdk/client-amplify": "^3.624.0",
         "@aws-sdk/client-cloudformation": "^3.624.0",
         "@aws-sdk/client-s3": "^3.624.0",
@@ -580,16 +592,16 @@
       }
     },
     "node_modules/@aws-amplify/backend-data": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-data/-/backend-data-1.1.2.tgz",
-      "integrity": "sha512-DwPsLezW5xqWrSR53H6C9g/dO14/bCtA9trQxHWnB3aIKNdhdoAgHuNU3RiNSGqJ6L6d4SIuOX5T/X4zkJo7Ug==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-data/-/backend-data-1.1.4.tgz",
+      "integrity": "sha512-qKK/t4VSH01P8OBA4yoNwqPKjVleQeQGZMo2S9voHMNk7C2hqBj0ztggMjhdiiVTYw8ZGIFMN1MFm05zdOJPqQ==",
       "dev": true,
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
-        "@aws-amplify/backend-output-storage": "^1.1.1",
-        "@aws-amplify/data-construct": "^1.9.1",
+        "@aws-amplify/backend-output-storage": "^1.1.2",
+        "@aws-amplify/data-construct": "^1.10.1",
         "@aws-amplify/data-schema-types": "^1.1.1",
-        "@aws-amplify/plugin-types": "^1.2.1"
+        "@aws-amplify/plugin-types": "^1.2.2"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.152.0",
@@ -597,13 +609,13 @@
       }
     },
     "node_modules/@aws-amplify/backend-deployer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-deployer/-/backend-deployer-1.1.0.tgz",
-      "integrity": "sha512-0OhAG92/I7octFn/H4gf8foTHfqo2NMDlDa81paoL56tbl5xnxA+K4Pzpwt5URPI8RjzDTGsiIiSXmfUFR5cQA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-deployer/-/backend-deployer-1.1.5.tgz",
+      "integrity": "sha512-dJSF2+PdQoWySEgLQclCMaOHhTVFWjlaNbgdYR8CT/k0mjvSimSDFFRjp6BulyzrgjmKVudJgjxb11xvcswNnA==",
       "dev": true,
       "dependencies": {
         "@aws-amplify/platform-core": "^1.0.6",
-        "@aws-amplify/plugin-types": "^1.2.1",
+        "@aws-amplify/plugin-types": "^1.2.2",
         "execa": "^8.0.1",
         "tsx": "^4.6.1"
       },
@@ -613,14 +625,14 @@
       }
     },
     "node_modules/@aws-amplify/backend-function": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-function/-/backend-function-1.3.4.tgz",
-      "integrity": "sha512-jOHytx3HifiR3dINw7S862TuRNFR0QuN+3fGrlRb7En/LRMK1RVsasGImF5GFHPupRmtV2XnSdnNJfr5SRr1qg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-function/-/backend-function-1.7.0.tgz",
+      "integrity": "sha512-tbA8eanmo81lB6Lzz4q5bHM5/xx+fCGa2VCE64axkQirWr5wjgZH+ZTXYUaocY//CxO/sThjKrDk+Xu/2ga/KA==",
       "dev": true,
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
-        "@aws-amplify/backend-output-storage": "^1.1.1",
-        "@aws-amplify/plugin-types": "^1.2.1",
+        "@aws-amplify/backend-output-storage": "^1.1.2",
+        "@aws-amplify/plugin-types": "^1.3.0",
         "execa": "^8.0.1"
       },
       "peerDependencies": {
@@ -629,47 +641,48 @@
       }
     },
     "node_modules/@aws-amplify/backend-output-schemas": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-output-schemas/-/backend-output-schemas-1.2.0.tgz",
-      "integrity": "sha512-UMQfPlfzyvYsV9A/MyoFm8T87MxsLZBzABSkmD5Y/sh8XTIJlqRHibzKStoN7xuK5S1Iz1okRVoxhFxSy0alrg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-output-schemas/-/backend-output-schemas-1.3.0.tgz",
+      "integrity": "sha512-uXzl0tnKY8zLpiLxdLd+hK5MtfABEKa0CxPuuDeiEh0ywQ+oGCtFwXXSkTP+fhnHehBuwOtjFmn/01vX+ufj6g==",
       "dev": true,
       "peerDependencies": {
         "zod": "^3.22.2"
       }
     },
     "node_modules/@aws-amplify/backend-output-storage": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-output-storage/-/backend-output-storage-1.1.1.tgz",
-      "integrity": "sha512-eXMz0HyM3kt52uexbYoURa57OFlRqcvQK1NqfJrHVBJfboFTY6hvBLmCLePcLcz/qeNUUP8ueYvRsI+rtxFCcw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-output-storage/-/backend-output-storage-1.1.2.tgz",
+      "integrity": "sha512-pKeYg33znqxRTWTDHp4D+w4lymhLeAMMn5ttlrYo2Kj2aSyI7TZs9pyhRa8cukhHgMuI51YBIZRejizjhIVXVA==",
       "dev": true,
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.2.0",
-        "@aws-amplify/platform-core": "^1.0.6"
+        "@aws-amplify/platform-core": "^1.0.6",
+        "@aws-amplify/plugin-types": "^1.2.2"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.152.0"
       }
     },
     "node_modules/@aws-amplify/backend-secret": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-secret/-/backend-secret-1.1.0.tgz",
-      "integrity": "sha512-4PSR4ughl0YVJLpnhEG5b1PQ7WXm/DlaHcWhQH07dzqUkDiQzEqt1nEXvhtFt7qDWnh1gUBhW7O4ZQIeN3+SIg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-secret/-/backend-secret-1.1.4.tgz",
+      "integrity": "sha512-97ah+yVK30+OtCXl5MruO81EJO+aXMdVlbOYvO7ZhEnOwe6vVUoHBhg8FsIV+cc/zDdNZK4xXAPUwkefwM4eFg==",
       "dev": true,
       "dependencies": {
         "@aws-amplify/platform-core": "^1.0.5",
-        "@aws-amplify/plugin-types": "^1.1.1",
+        "@aws-amplify/plugin-types": "^1.2.2",
         "@aws-sdk/client-ssm": "^3.624.0"
       }
     },
     "node_modules/@aws-amplify/backend-storage": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-storage/-/backend-storage-1.1.2.tgz",
-      "integrity": "sha512-a0S5kjnT93ebsdnc6SwmH1ujYgdwNSy3chjJ2TM9yJnyA38je5pf2ZprMABAONSona5uGzJO4o9wkvfSQdRO5g==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/backend-storage/-/backend-storage-1.2.1.tgz",
+      "integrity": "sha512-FmGs0rKy2G0El/LNepmOXP8wNNcpU/CmOOBBU+znd85TYONqTH1rpAgNKi1+xYWbNP2Y49YS3xRkWHoouNH/jg==",
       "dev": true,
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^1.2.0",
-        "@aws-amplify/backend-output-storage": "^1.1.1",
-        "@aws-amplify/plugin-types": "^1.2.1"
+        "@aws-amplify/backend-output-schemas": "^1.2.1",
+        "@aws-amplify/backend-output-storage": "^1.1.2",
+        "@aws-amplify/plugin-types": "^1.3.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.152.0",
@@ -677,9 +690,9 @@
       }
     },
     "node_modules/@aws-amplify/cli-core": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/cli-core/-/cli-core-1.1.2.tgz",
-      "integrity": "sha512-CDoRR0v8ZePt6fS2uL3y5b7mt+7gxK3kmiBLKxkHa1MNgctSWFeWKh/OwYM9cWQm63IqAeGZP6IeX9hsw07Slw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/cli-core/-/cli-core-1.1.3.tgz",
+      "integrity": "sha512-393vnMRyahSRyEBfWAZX1ItKz5PHX5+2wN81TJYNNXGjuN6Hl4My97+CNwALM8kztb3NXyapISsEspx8zGZXUw==",
       "dev": true,
       "dependencies": {
         "@aws-amplify/platform-core": "^1.0.5",
@@ -689,15 +702,16 @@
       }
     },
     "node_modules/@aws-amplify/client-config": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/client-config/-/client-config-1.2.1.tgz",
-      "integrity": "sha512-RjOQl8Gtdqc7iIDh34dKmOOEwQkzvFbuVfzwT646Ws2IxdhxdygfT78uS/2bu/glmlqYSD9DFK/ZfMsMUhSl4A==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/client-config/-/client-config-1.4.0.tgz",
+      "integrity": "sha512-Wq8XcydP4OMCUvmzbOv3hEYBIkmt2I2Aybx9yBCXCHYm1X/5dB1Kw6RT0Ci5TtMr1BiWnZpZ6oqEOujFJ4q+WA==",
       "dev": true,
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^1.2.0",
-        "@aws-amplify/deployed-backend-client": "^1.4.0",
-        "@aws-amplify/model-generator": "^1.0.5",
-        "@aws-amplify/platform-core": "^1.0.5",
+        "@aws-amplify/backend-output-schemas": "^1.2.1",
+        "@aws-amplify/deployed-backend-client": "^1.4.1",
+        "@aws-amplify/model-generator": "^1.0.7",
+        "@aws-amplify/platform-core": "^1.0.7",
+        "@aws-amplify/plugin-types": "^1.2.2",
         "zod": "^3.22.2"
       },
       "peerDependencies": {
@@ -763,9 +777,9 @@
       }
     },
     "node_modules/@aws-amplify/core": {
-      "version": "6.3.11",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.3.11.tgz",
-      "integrity": "sha512-Y0Ms8wEIhRHpdsLrfx1CgpvsL2GXxwtWRdY8+d0zPL03aWBKtH3NT1O0iWBoHl33xngEvWwdu8NX93bZqhzm8g==",
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.4.6.tgz",
+      "integrity": "sha512-OrjMe5W8vWxLddftw6L1o+vc9vlx+M/kwkoA03LFWIW4D6FenKKcU7CkC1EYBG5JQt6DB/hH/reKwgINTi3uxg==",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/types": "3.398.0",
@@ -800,29 +814,15 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-amplify/core/node_modules/@smithy/util-hex-encoding": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
-      "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-amplify/data-construct": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/data-construct/-/data-construct-1.9.6.tgz",
-      "integrity": "sha512-Nuh/UmyhlAPBcM08fSonhUMPB24A3Yl2SdGmTNjDMXdxzycjaKEzvGBiOI8RKI1p25R21AEoAnOiG0bZ4DAJjw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/data-construct/-/data-construct-1.11.1.tgz",
+      "integrity": "sha512-JPNfhkaH2i4UAglNJRF+6d//1UH8gRjpcsZFndwUSPJqUI/cLqSbzdKmqYsgY+GKmWtvGfbqRg7w8adQm3wqag==",
       "bundleDependencies": [
         "@aws-amplify/backend-output-schemas",
         "@aws-amplify/backend-output-storage",
-        "@aws-amplify/graphql-transformer",
-        "@aws-amplify/graphql-transformer-core",
-        "@aws-amplify/graphql-transformer-interfaces",
-        "zod",
         "@aws-amplify/graphql-auth-transformer",
+        "@aws-amplify/graphql-conversation-transformer",
         "@aws-amplify/graphql-default-value-transformer",
         "@aws-amplify/graphql-directives",
         "@aws-amplify/graphql-function-transformer",
@@ -834,343 +834,574 @@
         "@aws-amplify/graphql-relational-transformer",
         "@aws-amplify/graphql-searchable-transformer",
         "@aws-amplify/graphql-sql-transformer",
+        "@aws-amplify/graphql-generation-transformer",
+        "@aws-amplify/ai-constructs",
+        "@aws-amplify/graphql-transformer",
+        "@aws-amplify/graphql-transformer-core",
+        "@aws-amplify/graphql-transformer-interfaces",
         "@aws-amplify/platform-core",
         "@aws-amplify/plugin-types",
-        "fs-extra",
-        "graphql",
-        "graphql-transformer-common",
-        "hjson",
-        "lodash",
-        "md5",
-        "object-hash",
-        "ts-dedent",
+        "@aws-sdk/client-bedrock-runtime",
+        "@smithy/eventstream-serde-browser",
+        "@smithy/eventstream-serde-config-resolver",
+        "@smithy/eventstream-serde-node",
+        "@smithy/eventstream-serde-universal",
+        "@smithy/eventstream-codec",
+        "@aws-crypto/crc32",
         "charenc",
         "crypt",
+        "fs-extra",
         "graceful-fs",
+        "graphql",
         "graphql-mapping-template",
+        "graphql-transformer-common",
+        "hjson",
         "immer",
         "is-buffer",
         "jsonfile",
         "libphonenumber-js",
+        "lodash",
+        "md5",
+        "object-hash",
         "pluralize",
-        "universalify"
+        "ts-dedent",
+        "universalify",
+        "zod",
+        "@aws-sdk/client-sts",
+        "is-ci",
+        "lodash.mergewith",
+        "uuid",
+        "@aws-crypto/sha256-browser",
+        "@aws-crypto/sha256-js",
+        "@aws-sdk/client-sso-oidc",
+        "@aws-sdk/core",
+        "@aws-sdk/credential-provider-node",
+        "@aws-sdk/middleware-host-header",
+        "@aws-sdk/middleware-logger",
+        "@aws-sdk/middleware-recursion-detection",
+        "@aws-sdk/middleware-user-agent",
+        "@aws-sdk/region-config-resolver",
+        "@aws-sdk/types",
+        "@aws-sdk/util-endpoints",
+        "@aws-sdk/util-user-agent-browser",
+        "@aws-sdk/util-user-agent-node",
+        "@smithy/config-resolver",
+        "@smithy/core",
+        "@smithy/fetch-http-handler",
+        "@smithy/hash-node",
+        "@smithy/invalid-dependency",
+        "@smithy/middleware-content-length",
+        "@smithy/middleware-endpoint",
+        "@smithy/middleware-retry",
+        "@smithy/middleware-serde",
+        "@smithy/middleware-stack",
+        "@smithy/node-config-provider",
+        "@smithy/node-http-handler",
+        "@smithy/protocol-http",
+        "@smithy/smithy-client",
+        "@smithy/types",
+        "@smithy/url-parser",
+        "@smithy/util-base64",
+        "@smithy/util-body-length-browser",
+        "@smithy/util-body-length-node",
+        "@smithy/util-defaults-mode-browser",
+        "@smithy/util-defaults-mode-node",
+        "@smithy/util-endpoints",
+        "@smithy/util-middleware",
+        "@smithy/util-retry",
+        "@smithy/util-utf8",
+        "tslib",
+        "ci-info",
+        "@aws-crypto/supports-web-crypto",
+        "@aws-crypto/util",
+        "@aws-sdk/util-locate-window",
+        "@smithy/signature-v4",
+        "fast-xml-parser",
+        "@aws-sdk/credential-provider-env",
+        "@aws-sdk/credential-provider-http",
+        "@aws-sdk/credential-provider-ini",
+        "@aws-sdk/credential-provider-process",
+        "@aws-sdk/credential-provider-sso",
+        "@aws-sdk/credential-provider-web-identity",
+        "@smithy/credential-provider-imds",
+        "@smithy/property-provider",
+        "@smithy/shared-ini-file-loader",
+        "@smithy/util-config-provider",
+        "bowser",
+        "@smithy/querystring-builder",
+        "@smithy/util-buffer-from",
+        "@smithy/service-error-classification",
+        "@smithy/abort-controller",
+        "@smithy/util-stream",
+        "@smithy/querystring-parser",
+        "@smithy/is-array-buffer",
+        "@smithy/util-hex-encoding",
+        "@smithy/util-uri-escape",
+        "strnum",
+        "@aws-sdk/token-providers",
+        "@aws-sdk/client-sso",
+        "semver"
       ],
       "dev": true,
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.4.0",
-        "@aws-amplify/backend-output-storage": "^0.2.2",
-        "@aws-amplify/graphql-api-construct": "1.11.6",
-        "@aws-amplify/graphql-auth-transformer": "4.0.0",
-        "@aws-amplify/graphql-default-value-transformer": "3.0.0",
-        "@aws-amplify/graphql-directives": "2.0.0",
-        "@aws-amplify/graphql-function-transformer": "3.0.0",
-        "@aws-amplify/graphql-http-transformer": "3.0.0",
-        "@aws-amplify/graphql-index-transformer": "3.0.0",
-        "@aws-amplify/graphql-maps-to-transformer": "4.0.0",
-        "@aws-amplify/graphql-model-transformer": "3.0.0",
-        "@aws-amplify/graphql-predictions-transformer": "3.0.0",
-        "@aws-amplify/graphql-relational-transformer": "3.0.0",
-        "@aws-amplify/graphql-searchable-transformer": "3.0.0",
-        "@aws-amplify/graphql-sql-transformer": "0.4.0",
-        "@aws-amplify/graphql-transformer": "2.0.0",
-        "@aws-amplify/graphql-transformer-core": "3.0.0",
-        "@aws-amplify/graphql-transformer-interfaces": "4.0.0",
-        "@aws-amplify/platform-core": "^0.2.0",
-        "@aws-amplify/plugin-types": "^0.4.1",
+        "@aws-amplify/ai-constructs": "^0.2.0",
+        "@aws-amplify/backend-output-schemas": "^1.0.0",
+        "@aws-amplify/backend-output-storage": "^1.0.0",
+        "@aws-amplify/graphql-api-construct": "1.15.1",
+        "@aws-amplify/graphql-auth-transformer": "4.1.4",
+        "@aws-amplify/graphql-conversation-transformer": "0.4.0",
+        "@aws-amplify/graphql-default-value-transformer": "3.1.1",
+        "@aws-amplify/graphql-directives": "2.4.0",
+        "@aws-amplify/graphql-function-transformer": "3.1.3",
+        "@aws-amplify/graphql-generation-transformer": "0.2.4",
+        "@aws-amplify/graphql-http-transformer": "3.0.6",
+        "@aws-amplify/graphql-index-transformer": "3.0.6",
+        "@aws-amplify/graphql-maps-to-transformer": "4.0.6",
+        "@aws-amplify/graphql-model-transformer": "3.0.6",
+        "@aws-amplify/graphql-predictions-transformer": "3.0.6",
+        "@aws-amplify/graphql-relational-transformer": "3.0.6",
+        "@aws-amplify/graphql-searchable-transformer": "3.0.6",
+        "@aws-amplify/graphql-sql-transformer": "0.4.6",
+        "@aws-amplify/graphql-transformer": "2.1.4",
+        "@aws-amplify/graphql-transformer-core": "3.2.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.1.2",
+        "@aws-amplify/platform-core": "^1.0.0",
+        "@aws-amplify/plugin-types": "^1.0.0",
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.622.0",
+        "@aws-sdk/client-sso": "3.637.0",
+        "@aws-sdk/client-sso-oidc": "3.637.0",
+        "@aws-sdk/client-sts": "^3.624.0",
+        "@aws-sdk/core": "3.635.0",
+        "@aws-sdk/credential-provider-env": "3.620.1",
+        "@aws-sdk/credential-provider-http": "3.635.0",
+        "@aws-sdk/credential-provider-ini": "3.637.0",
+        "@aws-sdk/credential-provider-node": "3.637.0",
+        "@aws-sdk/credential-provider-process": "3.620.1",
+        "@aws-sdk/credential-provider-sso": "3.637.0",
+        "@aws-sdk/credential-provider-web-identity": "3.621.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.637.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/token-providers": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.637.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/abort-controller": "^3.1.1",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.4.0",
+        "@smithy/credential-provider-imds": "^3.2.0",
+        "@smithy/eventstream-codec": "^3.1.2",
+        "@smithy/eventstream-serde-browser": "^3.0.6",
+        "@smithy/eventstream-serde-config-resolver": "^3.0.3",
+        "@smithy/eventstream-serde-node": "^3.0.5",
+        "@smithy/eventstream-serde-universal": "^3.0.5",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.15",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/querystring-parser": "^3.0.3",
+        "@smithy/service-error-classification": "^3.0.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/signature-v4": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.15",
+        "@smithy/util-defaults-mode-node": "^3.0.15",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-stream": "^3.1.3",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "bowser": "^2.11.0",
         "charenc": "^0.0.2",
+        "ci-info": "^3.2.0",
         "crypt": "^0.0.2",
+        "fast-xml-parser": "4.4.1",
         "fs-extra": "^8.1.0",
-        "graceful-fs": "^4.2.11",
+        "graceful-fs": "^4.2.0",
         "graphql": "^15.5.0",
-        "graphql-mapping-template": "5.0.0",
-        "graphql-transformer-common": "5.0.0",
+        "graphql-mapping-template": "5.0.1",
+        "graphql-transformer-common": "5.0.1",
         "hjson": "^3.2.2",
         "immer": "^9.0.12",
-        "is-buffer": "^2.0.5",
-        "jsonfile": "^6.1.0",
+        "is-buffer": "~1.1.6",
+        "is-ci": "^3.0.1",
+        "jsonfile": "^4.0.0",
         "libphonenumber-js": "1.9.47",
         "lodash": "^4.17.21",
-        "md5": "^2.3.0",
+        "lodash.mergewith": "^4.6.2",
+        "md5": "^2.2.1",
         "object-hash": "^3.0.0",
-        "pluralize": "^8.0.0",
+        "pluralize": "8.0.0",
+        "semver": "^7.6.3",
+        "strnum": "^1.0.5",
         "ts-dedent": "^2.0.0",
-        "universalify": "^2.0.0",
-        "zod": "^3.22.3"
+        "tslib": "^2.6.2",
+        "universalify": "^0.1.0",
+        "uuid": "^9.0.1",
+        "zod": "^3.22.2"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.129.0",
+        "aws-cdk-lib": "^2.158.0",
         "constructs": "^10.3.0"
       }
     },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/ai-constructs": {
+      "version": "0.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/plugin-types": "^1.0.1",
+        "@aws-sdk/client-bedrock-runtime": "^3.622.0",
+        "@smithy/types": "^3.3.0"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.152.0",
+        "constructs": "^10.0.0"
+      }
+    },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/backend-output-schemas": {
-      "version": "0.4.0",
+      "version": "1.2.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "peerDependencies": {
-        "zod": "^3.21.4"
+        "zod": "^3.22.2"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/backend-output-storage": {
-      "version": "0.2.2",
+      "version": "1.1.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.4.0",
-        "@aws-amplify/platform-core": "^0.2.0"
+        "@aws-amplify/backend-output-schemas": "^1.2.0",
+        "@aws-amplify/platform-core": "^1.0.6"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.103.0"
+        "aws-cdk-lib": "^2.152.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-auth-transformer": {
-      "version": "4.0.0",
+      "version": "4.1.4",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.0.0",
-        "@aws-amplify/graphql-model-transformer": "3.0.0",
-        "@aws-amplify/graphql-relational-transformer": "3.0.0",
-        "@aws-amplify/graphql-transformer-core": "3.0.0",
-        "@aws-amplify/graphql-transformer-interfaces": "4.0.0",
+        "@aws-amplify/graphql-directives": "2.4.0",
+        "@aws-amplify/graphql-model-transformer": "3.0.6",
+        "@aws-amplify/graphql-relational-transformer": "3.0.6",
+        "@aws-amplify/graphql-transformer-core": "3.2.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.1.2",
         "graphql": "^15.5.0",
-        "graphql-mapping-template": "5.0.0",
-        "graphql-transformer-common": "5.0.0",
+        "graphql-mapping-template": "5.0.1",
+        "graphql-transformer-common": "5.0.1",
         "lodash": "^4.17.21",
         "md5": "^2.3.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.129.0",
+        "aws-cdk-lib": "^2.158.0",
         "constructs": "^10.3.0"
       }
     },
-    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-default-value-transformer": {
-      "version": "3.0.0",
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-conversation-transformer": {
+      "version": "0.4.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.0.0",
-        "@aws-amplify/graphql-transformer-core": "3.0.0",
-        "@aws-amplify/graphql-transformer-interfaces": "4.0.0",
+        "@aws-amplify/ai-constructs": "^0.2.0",
+        "@aws-amplify/graphql-directives": "2.4.0",
+        "@aws-amplify/graphql-index-transformer": "3.0.6",
+        "@aws-amplify/graphql-model-transformer": "3.0.6",
+        "@aws-amplify/graphql-relational-transformer": "3.0.6",
+        "@aws-amplify/graphql-transformer-core": "3.2.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.1.2",
         "graphql": "^15.5.0",
-        "graphql-mapping-template": "5.0.0",
-        "graphql-transformer-common": "5.0.0",
+        "graphql-mapping-template": "5.0.1",
+        "graphql-transformer-common": "5.0.1",
+        "immer": "^9.0.12",
+        "semver": "^7.6.3"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.158.0",
+        "constructs": "^10.3.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-default-value-transformer": {
+      "version": "3.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/graphql-directives": "2.4.0",
+        "@aws-amplify/graphql-transformer-core": "3.2.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.1.2",
+        "graphql": "^15.5.0",
+        "graphql-mapping-template": "5.0.1",
+        "graphql-transformer-common": "5.0.1",
         "libphonenumber-js": "1.9.47"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-directives": {
-      "version": "2.0.0",
+      "version": "2.4.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-function-transformer": {
-      "version": "3.0.0",
+      "version": "3.1.3",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.0.0",
-        "@aws-amplify/graphql-transformer-core": "3.0.0",
-        "@aws-amplify/graphql-transformer-interfaces": "4.0.0",
+        "@aws-amplify/graphql-directives": "2.4.0",
+        "@aws-amplify/graphql-transformer-core": "3.2.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.1.2",
         "graphql": "^15.5.0",
-        "graphql-mapping-template": "5.0.0",
-        "graphql-transformer-common": "5.0.0"
+        "graphql-mapping-template": "5.0.1",
+        "graphql-transformer-common": "5.0.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.129.0",
+        "aws-cdk-lib": "^2.158.0",
+        "constructs": "^10.3.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-generation-transformer": {
+      "version": "0.2.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/graphql-directives": "2.4.0",
+        "@aws-amplify/graphql-transformer-core": "3.2.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.1.2",
+        "graphql": "^15.5.0",
+        "graphql-mapping-template": "5.0.1",
+        "graphql-transformer-common": "5.0.1",
+        "immer": "^9.0.12"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.158.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-http-transformer": {
-      "version": "3.0.0",
+      "version": "3.0.6",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.0.0",
-        "@aws-amplify/graphql-transformer-core": "3.0.0",
-        "@aws-amplify/graphql-transformer-interfaces": "4.0.0",
+        "@aws-amplify/graphql-directives": "2.4.0",
+        "@aws-amplify/graphql-transformer-core": "3.2.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.1.2",
         "graphql": "^15.5.0",
-        "graphql-mapping-template": "5.0.0",
-        "graphql-transformer-common": "5.0.0"
+        "graphql-mapping-template": "5.0.1",
+        "graphql-transformer-common": "5.0.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.129.0",
+        "aws-cdk-lib": "^2.158.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-index-transformer": {
-      "version": "3.0.0",
+      "version": "3.0.6",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.0.0",
-        "@aws-amplify/graphql-model-transformer": "3.0.0",
-        "@aws-amplify/graphql-transformer-core": "3.0.0",
-        "@aws-amplify/graphql-transformer-interfaces": "4.0.0",
+        "@aws-amplify/graphql-directives": "2.4.0",
+        "@aws-amplify/graphql-model-transformer": "3.0.6",
+        "@aws-amplify/graphql-transformer-core": "3.2.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.1.2",
         "graphql": "^15.5.0",
-        "graphql-mapping-template": "5.0.0",
-        "graphql-transformer-common": "5.0.0"
+        "graphql-mapping-template": "5.0.1",
+        "graphql-transformer-common": "5.0.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.129.0",
+        "aws-cdk-lib": "^2.158.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-maps-to-transformer": {
-      "version": "4.0.0",
+      "version": "4.0.6",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.0.0",
-        "@aws-amplify/graphql-transformer-core": "3.0.0",
-        "@aws-amplify/graphql-transformer-interfaces": "4.0.0",
-        "graphql-mapping-template": "5.0.0",
-        "graphql-transformer-common": "5.0.0"
+        "@aws-amplify/graphql-directives": "2.4.0",
+        "@aws-amplify/graphql-transformer-core": "3.2.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.1.2",
+        "graphql-mapping-template": "5.0.1",
+        "graphql-transformer-common": "5.0.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.129.0",
+        "aws-cdk-lib": "^2.158.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-model-transformer": {
-      "version": "3.0.0",
+      "version": "3.0.6",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.0.0",
-        "@aws-amplify/graphql-transformer-core": "3.0.0",
-        "@aws-amplify/graphql-transformer-interfaces": "4.0.0",
+        "@aws-amplify/graphql-directives": "2.4.0",
+        "@aws-amplify/graphql-transformer-core": "3.2.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.1.2",
         "graphql": "^15.5.0",
-        "graphql-mapping-template": "5.0.0",
-        "graphql-transformer-common": "5.0.0"
+        "graphql-mapping-template": "5.0.1",
+        "graphql-transformer-common": "5.0.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.129.0",
+        "aws-cdk-lib": "^2.158.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-predictions-transformer": {
-      "version": "3.0.0",
+      "version": "3.0.6",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.0.0",
-        "@aws-amplify/graphql-transformer-core": "3.0.0",
-        "@aws-amplify/graphql-transformer-interfaces": "4.0.0",
+        "@aws-amplify/graphql-directives": "2.4.0",
+        "@aws-amplify/graphql-transformer-core": "3.2.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.1.2",
         "graphql": "^15.5.0",
-        "graphql-mapping-template": "5.0.0",
-        "graphql-transformer-common": "5.0.0"
+        "graphql-mapping-template": "5.0.1",
+        "graphql-transformer-common": "5.0.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.129.0",
+        "aws-cdk-lib": "^2.158.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-relational-transformer": {
-      "version": "3.0.0",
+      "version": "3.0.6",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.0.0",
-        "@aws-amplify/graphql-index-transformer": "3.0.0",
-        "@aws-amplify/graphql-model-transformer": "3.0.0",
-        "@aws-amplify/graphql-transformer-core": "3.0.0",
-        "@aws-amplify/graphql-transformer-interfaces": "4.0.0",
+        "@aws-amplify/graphql-directives": "2.4.0",
+        "@aws-amplify/graphql-index-transformer": "3.0.6",
+        "@aws-amplify/graphql-model-transformer": "3.0.6",
+        "@aws-amplify/graphql-transformer-core": "3.2.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.1.2",
         "graphql": "^15.5.0",
-        "graphql-mapping-template": "5.0.0",
-        "graphql-transformer-common": "5.0.0",
+        "graphql-mapping-template": "5.0.1",
+        "graphql-transformer-common": "5.0.1",
         "immer": "^9.0.12"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.129.0",
+        "aws-cdk-lib": "^2.158.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-searchable-transformer": {
-      "version": "3.0.0",
+      "version": "3.0.6",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.0.0",
-        "@aws-amplify/graphql-model-transformer": "3.0.0",
-        "@aws-amplify/graphql-transformer-core": "3.0.0",
-        "@aws-amplify/graphql-transformer-interfaces": "4.0.0",
+        "@aws-amplify/graphql-directives": "2.4.0",
+        "@aws-amplify/graphql-model-transformer": "3.0.6",
+        "@aws-amplify/graphql-transformer-core": "3.2.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.1.2",
         "graphql": "^15.5.0",
-        "graphql-mapping-template": "5.0.0",
-        "graphql-transformer-common": "5.0.0"
+        "graphql-mapping-template": "5.0.1",
+        "graphql-transformer-common": "5.0.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.129.0",
+        "aws-cdk-lib": "^2.158.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-sql-transformer": {
-      "version": "0.4.0",
+      "version": "0.4.6",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.0.0",
-        "@aws-amplify/graphql-model-transformer": "3.0.0",
-        "@aws-amplify/graphql-transformer-core": "3.0.0",
-        "@aws-amplify/graphql-transformer-interfaces": "4.0.0",
+        "@aws-amplify/graphql-directives": "2.4.0",
+        "@aws-amplify/graphql-model-transformer": "3.0.6",
+        "@aws-amplify/graphql-transformer-core": "3.2.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.1.2",
         "graphql": "^15.5.0",
-        "graphql-mapping-template": "5.0.0",
-        "graphql-transformer-common": "5.0.0"
+        "graphql-mapping-template": "5.0.1",
+        "graphql-transformer-common": "5.0.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.129.0",
+        "aws-cdk-lib": "^2.158.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-transformer": {
-      "version": "2.0.0",
+      "version": "2.1.4",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-auth-transformer": "4.0.0",
-        "@aws-amplify/graphql-default-value-transformer": "3.0.0",
-        "@aws-amplify/graphql-function-transformer": "3.0.0",
-        "@aws-amplify/graphql-http-transformer": "3.0.0",
-        "@aws-amplify/graphql-index-transformer": "3.0.0",
-        "@aws-amplify/graphql-maps-to-transformer": "4.0.0",
-        "@aws-amplify/graphql-model-transformer": "3.0.0",
-        "@aws-amplify/graphql-predictions-transformer": "3.0.0",
-        "@aws-amplify/graphql-relational-transformer": "3.0.0",
-        "@aws-amplify/graphql-searchable-transformer": "3.0.0",
-        "@aws-amplify/graphql-sql-transformer": "0.4.0",
-        "@aws-amplify/graphql-transformer-core": "3.0.0",
-        "@aws-amplify/graphql-transformer-interfaces": "4.0.0"
+        "@aws-amplify/graphql-auth-transformer": "4.1.4",
+        "@aws-amplify/graphql-conversation-transformer": "0.4.0",
+        "@aws-amplify/graphql-default-value-transformer": "3.1.1",
+        "@aws-amplify/graphql-function-transformer": "3.1.3",
+        "@aws-amplify/graphql-generation-transformer": "0.2.4",
+        "@aws-amplify/graphql-http-transformer": "3.0.6",
+        "@aws-amplify/graphql-index-transformer": "3.0.6",
+        "@aws-amplify/graphql-maps-to-transformer": "4.0.6",
+        "@aws-amplify/graphql-model-transformer": "3.0.6",
+        "@aws-amplify/graphql-predictions-transformer": "3.0.6",
+        "@aws-amplify/graphql-relational-transformer": "3.0.6",
+        "@aws-amplify/graphql-searchable-transformer": "3.0.6",
+        "@aws-amplify/graphql-sql-transformer": "0.4.6",
+        "@aws-amplify/graphql-transformer-core": "3.2.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.1.2"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.129.0",
+        "aws-cdk-lib": "^2.158.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-transformer-core": {
-      "version": "3.0.0",
+      "version": "3.2.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.0.0",
-        "@aws-amplify/graphql-transformer-interfaces": "4.0.0",
+        "@aws-amplify/graphql-directives": "2.4.0",
+        "@aws-amplify/graphql-transformer-interfaces": "4.1.2",
         "fs-extra": "^8.1.0",
         "graphql": "^15.5.0",
-        "graphql-mapping-template": "5.0.0",
-        "graphql-transformer-common": "5.0.0",
+        "graphql-mapping-template": "5.0.1",
+        "graphql-transformer-common": "5.0.1",
         "hjson": "^3.2.2",
         "lodash": "^4.17.21",
         "md5": "^2.3.0",
@@ -1178,12 +1409,12 @@
         "ts-dedent": "^2.0.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.129.0",
+        "aws-cdk-lib": "^2.158.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/graphql-transformer-interfaces": {
-      "version": "4.0.0",
+      "version": "4.1.2",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -1191,28 +1422,2222 @@
         "graphql": "^15.5.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.129.0",
+        "aws-cdk-lib": "^2.158.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/platform-core": {
-      "version": "0.2.0",
+      "version": "1.1.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/plugin-types": "^0.4.0"
+        "@aws-amplify/plugin-types": "^1.2.1",
+        "@aws-sdk/client-sts": "^3.624.0",
+        "is-ci": "^3.0.1",
+        "lodash.mergewith": "^4.6.2",
+        "semver": "^7.6.3",
+        "uuid": "^9.0.1",
+        "zod": "^3.22.2"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/@aws-amplify/plugin-types": {
-      "version": "0.4.1",
+      "version": "1.2.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "peerDependencies": {
-        "aws-cdk-lib": "^2.103.0",
+        "@aws-sdk/types": "^3.609.0",
+        "aws-cdk-lib": "^2.152.0",
         "constructs": "^10.0.0"
       }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/crc32/node_modules/@aws-sdk/types": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/sha256-browser/node_modules/@aws-sdk/types": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/sha256-js/node_modules/@aws-sdk/types": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/util/node_modules/@aws-sdk/types": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.651.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.651.1",
+        "@aws-sdk/client-sts": "3.651.1",
+        "@aws-sdk/core": "3.651.1",
+        "@aws-sdk/credential-provider-node": "3.651.1",
+        "@aws-sdk/middleware-host-header": "3.649.0",
+        "@aws-sdk/middleware-logger": "3.649.0",
+        "@aws-sdk/middleware-recursion-detection": "3.649.0",
+        "@aws-sdk/middleware-user-agent": "3.649.0",
+        "@aws-sdk/region-config-resolver": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@aws-sdk/util-endpoints": "3.649.0",
+        "@aws-sdk/util-user-agent-browser": "3.649.0",
+        "@aws-sdk/util-user-agent-node": "3.649.0",
+        "@smithy/config-resolver": "^3.0.6",
+        "@smithy/core": "^2.4.1",
+        "@smithy/eventstream-serde-browser": "^3.0.7",
+        "@smithy/eventstream-serde-config-resolver": "^3.0.4",
+        "@smithy/eventstream-serde-node": "^3.0.6",
+        "@smithy/fetch-http-handler": "^3.2.5",
+        "@smithy/hash-node": "^3.0.4",
+        "@smithy/invalid-dependency": "^3.0.4",
+        "@smithy/middleware-content-length": "^3.0.6",
+        "@smithy/middleware-endpoint": "^3.1.1",
+        "@smithy/middleware-retry": "^3.0.16",
+        "@smithy/middleware-serde": "^3.0.4",
+        "@smithy/middleware-stack": "^3.0.4",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/node-http-handler": "^3.2.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/smithy-client": "^3.3.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/url-parser": "^3.0.4",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.16",
+        "@smithy/util-defaults-mode-node": "^3.0.16",
+        "@smithy/util-endpoints": "^2.1.0",
+        "@smithy/util-middleware": "^3.0.4",
+        "@smithy/util-retry": "^3.0.4",
+        "@smithy/util-stream": "^3.1.4",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/client-sso": {
+      "version": "3.651.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.651.1",
+        "@aws-sdk/middleware-host-header": "3.649.0",
+        "@aws-sdk/middleware-logger": "3.649.0",
+        "@aws-sdk/middleware-recursion-detection": "3.649.0",
+        "@aws-sdk/middleware-user-agent": "3.649.0",
+        "@aws-sdk/region-config-resolver": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@aws-sdk/util-endpoints": "3.649.0",
+        "@aws-sdk/util-user-agent-browser": "3.649.0",
+        "@aws-sdk/util-user-agent-node": "3.649.0",
+        "@smithy/config-resolver": "^3.0.6",
+        "@smithy/core": "^2.4.1",
+        "@smithy/fetch-http-handler": "^3.2.5",
+        "@smithy/hash-node": "^3.0.4",
+        "@smithy/invalid-dependency": "^3.0.4",
+        "@smithy/middleware-content-length": "^3.0.6",
+        "@smithy/middleware-endpoint": "^3.1.1",
+        "@smithy/middleware-retry": "^3.0.16",
+        "@smithy/middleware-serde": "^3.0.4",
+        "@smithy/middleware-stack": "^3.0.4",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/node-http-handler": "^3.2.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/smithy-client": "^3.3.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/url-parser": "^3.0.4",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.16",
+        "@smithy/util-defaults-mode-node": "^3.0.16",
+        "@smithy/util-endpoints": "^2.1.0",
+        "@smithy/util-middleware": "^3.0.4",
+        "@smithy/util-retry": "^3.0.4",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.651.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.651.1",
+        "@aws-sdk/credential-provider-node": "3.651.1",
+        "@aws-sdk/middleware-host-header": "3.649.0",
+        "@aws-sdk/middleware-logger": "3.649.0",
+        "@aws-sdk/middleware-recursion-detection": "3.649.0",
+        "@aws-sdk/middleware-user-agent": "3.649.0",
+        "@aws-sdk/region-config-resolver": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@aws-sdk/util-endpoints": "3.649.0",
+        "@aws-sdk/util-user-agent-browser": "3.649.0",
+        "@aws-sdk/util-user-agent-node": "3.649.0",
+        "@smithy/config-resolver": "^3.0.6",
+        "@smithy/core": "^2.4.1",
+        "@smithy/fetch-http-handler": "^3.2.5",
+        "@smithy/hash-node": "^3.0.4",
+        "@smithy/invalid-dependency": "^3.0.4",
+        "@smithy/middleware-content-length": "^3.0.6",
+        "@smithy/middleware-endpoint": "^3.1.1",
+        "@smithy/middleware-retry": "^3.0.16",
+        "@smithy/middleware-serde": "^3.0.4",
+        "@smithy/middleware-stack": "^3.0.4",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/node-http-handler": "^3.2.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/smithy-client": "^3.3.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/url-parser": "^3.0.4",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.16",
+        "@smithy/util-defaults-mode-node": "^3.0.16",
+        "@smithy/util-endpoints": "^2.1.0",
+        "@smithy/util-middleware": "^3.0.4",
+        "@smithy/util-retry": "^3.0.4",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.651.1"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/core": {
+      "version": "3.651.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^2.4.1",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/signature-v4": "^4.1.1",
+        "@smithy/smithy-client": "^3.3.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/util-middleware": "^3.0.4",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/fetch-http-handler": "^3.2.5",
+        "@smithy/node-http-handler": "^3.2.0",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/smithy-client": "^3.3.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/util-stream": "^3.1.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.651.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.649.0",
+        "@aws-sdk/credential-provider-http": "3.649.0",
+        "@aws-sdk/credential-provider-process": "3.649.0",
+        "@aws-sdk/credential-provider-sso": "3.651.1",
+        "@aws-sdk/credential-provider-web-identity": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/credential-provider-imds": "^3.2.1",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.5",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.651.1"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.651.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.649.0",
+        "@aws-sdk/credential-provider-http": "3.649.0",
+        "@aws-sdk/credential-provider-ini": "3.651.1",
+        "@aws-sdk/credential-provider-process": "3.649.0",
+        "@aws-sdk/credential-provider-sso": "3.651.1",
+        "@aws-sdk/credential-provider-web-identity": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/credential-provider-imds": "^3.2.1",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.5",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.5",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.651.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.651.1",
+        "@aws-sdk/token-providers": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.5",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.649.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@aws-sdk/util-endpoints": "3.649.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/types": "^3.4.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/token-providers": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.5",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.649.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/types": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/util-endpoints": "^2.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/types": "^3.4.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sso": {
+      "version": "3.637.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.635.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.637.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.637.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.4.0",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.15",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.15",
+        "@smithy/util-defaults-mode-node": "^3.0.15",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.637.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.635.0",
+        "@aws-sdk/credential-provider-node": "3.637.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.637.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.637.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.4.0",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.15",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.15",
+        "@smithy/util-defaults-mode-node": "^3.0.15",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.637.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts": {
+      "version": "3.651.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.651.1",
+        "@aws-sdk/core": "3.651.1",
+        "@aws-sdk/credential-provider-node": "3.651.1",
+        "@aws-sdk/middleware-host-header": "3.649.0",
+        "@aws-sdk/middleware-logger": "3.649.0",
+        "@aws-sdk/middleware-recursion-detection": "3.649.0",
+        "@aws-sdk/middleware-user-agent": "3.649.0",
+        "@aws-sdk/region-config-resolver": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@aws-sdk/util-endpoints": "3.649.0",
+        "@aws-sdk/util-user-agent-browser": "3.649.0",
+        "@aws-sdk/util-user-agent-node": "3.649.0",
+        "@smithy/config-resolver": "^3.0.6",
+        "@smithy/core": "^2.4.1",
+        "@smithy/fetch-http-handler": "^3.2.5",
+        "@smithy/hash-node": "^3.0.4",
+        "@smithy/invalid-dependency": "^3.0.4",
+        "@smithy/middleware-content-length": "^3.0.6",
+        "@smithy/middleware-endpoint": "^3.1.1",
+        "@smithy/middleware-retry": "^3.0.16",
+        "@smithy/middleware-serde": "^3.0.4",
+        "@smithy/middleware-stack": "^3.0.4",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/node-http-handler": "^3.2.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/smithy-client": "^3.3.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/url-parser": "^3.0.4",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.16",
+        "@smithy/util-defaults-mode-node": "^3.0.16",
+        "@smithy/util-endpoints": "^2.1.0",
+        "@smithy/util-middleware": "^3.0.4",
+        "@smithy/util-retry": "^3.0.4",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/client-sso": {
+      "version": "3.651.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.651.1",
+        "@aws-sdk/middleware-host-header": "3.649.0",
+        "@aws-sdk/middleware-logger": "3.649.0",
+        "@aws-sdk/middleware-recursion-detection": "3.649.0",
+        "@aws-sdk/middleware-user-agent": "3.649.0",
+        "@aws-sdk/region-config-resolver": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@aws-sdk/util-endpoints": "3.649.0",
+        "@aws-sdk/util-user-agent-browser": "3.649.0",
+        "@aws-sdk/util-user-agent-node": "3.649.0",
+        "@smithy/config-resolver": "^3.0.6",
+        "@smithy/core": "^2.4.1",
+        "@smithy/fetch-http-handler": "^3.2.5",
+        "@smithy/hash-node": "^3.0.4",
+        "@smithy/invalid-dependency": "^3.0.4",
+        "@smithy/middleware-content-length": "^3.0.6",
+        "@smithy/middleware-endpoint": "^3.1.1",
+        "@smithy/middleware-retry": "^3.0.16",
+        "@smithy/middleware-serde": "^3.0.4",
+        "@smithy/middleware-stack": "^3.0.4",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/node-http-handler": "^3.2.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/smithy-client": "^3.3.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/url-parser": "^3.0.4",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.16",
+        "@smithy/util-defaults-mode-node": "^3.0.16",
+        "@smithy/util-endpoints": "^2.1.0",
+        "@smithy/util-middleware": "^3.0.4",
+        "@smithy/util-retry": "^3.0.4",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.651.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.651.1",
+        "@aws-sdk/credential-provider-node": "3.651.1",
+        "@aws-sdk/middleware-host-header": "3.649.0",
+        "@aws-sdk/middleware-logger": "3.649.0",
+        "@aws-sdk/middleware-recursion-detection": "3.649.0",
+        "@aws-sdk/middleware-user-agent": "3.649.0",
+        "@aws-sdk/region-config-resolver": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@aws-sdk/util-endpoints": "3.649.0",
+        "@aws-sdk/util-user-agent-browser": "3.649.0",
+        "@aws-sdk/util-user-agent-node": "3.649.0",
+        "@smithy/config-resolver": "^3.0.6",
+        "@smithy/core": "^2.4.1",
+        "@smithy/fetch-http-handler": "^3.2.5",
+        "@smithy/hash-node": "^3.0.4",
+        "@smithy/invalid-dependency": "^3.0.4",
+        "@smithy/middleware-content-length": "^3.0.6",
+        "@smithy/middleware-endpoint": "^3.1.1",
+        "@smithy/middleware-retry": "^3.0.16",
+        "@smithy/middleware-serde": "^3.0.4",
+        "@smithy/middleware-stack": "^3.0.4",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/node-http-handler": "^3.2.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/smithy-client": "^3.3.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/url-parser": "^3.0.4",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.16",
+        "@smithy/util-defaults-mode-node": "^3.0.16",
+        "@smithy/util-endpoints": "^2.1.0",
+        "@smithy/util-middleware": "^3.0.4",
+        "@smithy/util-retry": "^3.0.4",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.651.1"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/core": {
+      "version": "3.651.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^2.4.1",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/signature-v4": "^4.1.1",
+        "@smithy/smithy-client": "^3.3.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/util-middleware": "^3.0.4",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/fetch-http-handler": "^3.2.5",
+        "@smithy/node-http-handler": "^3.2.0",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/smithy-client": "^3.3.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/util-stream": "^3.1.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.651.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.649.0",
+        "@aws-sdk/credential-provider-http": "3.649.0",
+        "@aws-sdk/credential-provider-process": "3.649.0",
+        "@aws-sdk/credential-provider-sso": "3.651.1",
+        "@aws-sdk/credential-provider-web-identity": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/credential-provider-imds": "^3.2.1",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.5",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.651.1"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.651.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.649.0",
+        "@aws-sdk/credential-provider-http": "3.649.0",
+        "@aws-sdk/credential-provider-ini": "3.651.1",
+        "@aws-sdk/credential-provider-process": "3.649.0",
+        "@aws-sdk/credential-provider-sso": "3.651.1",
+        "@aws-sdk/credential-provider-web-identity": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/credential-provider-imds": "^3.2.1",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.5",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.5",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.651.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.651.1",
+        "@aws-sdk/token-providers": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.5",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.649.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@aws-sdk/util-endpoints": "3.649.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/types": "^3.4.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/token-providers": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.5",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.649.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/types": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/util-endpoints": "^2.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/types": "^3.4.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/core": {
+      "version": "3.635.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^2.4.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/signature-v4": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.620.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.635.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-stream": "^3.1.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.637.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.620.1",
+        "@aws-sdk/credential-provider-http": "3.635.0",
+        "@aws-sdk/credential-provider-process": "3.620.1",
+        "@aws-sdk/credential-provider-sso": "3.637.0",
+        "@aws-sdk/credential-provider-web-identity": "3.621.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/credential-provider-imds": "^3.2.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.637.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.637.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.620.1",
+        "@aws-sdk/credential-provider-http": "3.635.0",
+        "@aws-sdk/credential-provider-ini": "3.637.0",
+        "@aws-sdk/credential-provider-process": "3.620.1",
+        "@aws-sdk/credential-provider-sso": "3.637.0",
+        "@aws-sdk/credential-provider-web-identity": "3.621.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/credential-provider-imds": "^3.2.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.620.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.637.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.637.0",
+        "@aws-sdk/token-providers": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.621.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.621.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.620.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.609.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.620.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.637.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.637.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.614.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/token-providers": {
+      "version": "3.614.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.614.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/types": {
+      "version": "3.609.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.637.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-endpoints": "^2.0.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.568.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.609.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.614.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/abort-controller": {
+      "version": "3.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/config-resolver": {
+      "version": "3.0.8",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/core": {
+      "version": "2.4.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^3.1.3",
+        "@smithy/middleware-retry": "^3.0.18",
+        "@smithy/middleware-serde": "^3.0.6",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/smithy-client": "^3.3.2",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/credential-provider-imds": {
+      "version": "3.2.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/types": "^3.4.2",
+        "@smithy/url-parser": "^3.0.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/eventstream-codec": {
+      "version": "3.1.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/eventstream-serde-browser": {
+      "version": "3.0.9",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^3.0.8",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "3.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/eventstream-serde-node": {
+      "version": "3.0.8",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^3.0.8",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/eventstream-serde-universal": {
+      "version": "3.0.8",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^3.1.5",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/fetch-http-handler": {
+      "version": "3.2.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/querystring-builder": "^3.0.6",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/hash-node": {
+      "version": "3.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/invalid-dependency": {
+      "version": "3.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/middleware-content-length": {
+      "version": "3.0.8",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/middleware-endpoint": {
+      "version": "3.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^3.0.6",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "@smithy/url-parser": "^3.0.6",
+        "@smithy/util-middleware": "^3.0.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/middleware-retry": {
+      "version": "3.0.18",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/service-error-classification": "^3.0.6",
+        "@smithy/smithy-client": "^3.3.2",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-retry": "^3.0.6",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/middleware-serde": {
+      "version": "3.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/middleware-stack": {
+      "version": "3.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/shared-ini-file-loader": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/node-http-handler": {
+      "version": "3.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/querystring-builder": "^3.0.6",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/property-provider": {
+      "version": "3.1.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/protocol-http": {
+      "version": "4.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/querystring-builder": {
+      "version": "3.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/querystring-parser": {
+      "version": "3.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/service-error-classification": {
+      "version": "3.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/signature-v4": {
+      "version": "4.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/smithy-client": {
+      "version": "3.3.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^3.1.3",
+        "@smithy/middleware-stack": "^3.0.6",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-stream": "^3.1.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/types": {
+      "version": "3.4.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/url-parser": {
+      "version": "3.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^3.0.6",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-base64": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-body-length-browser": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-body-length-node": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-config-provider": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "3.0.18",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/smithy-client": "^3.3.2",
+        "@smithy/types": "^3.4.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-defaults-mode-node": {
+      "version": "3.0.18",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^3.0.8",
+        "@smithy/credential-provider-imds": "^3.2.3",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/smithy-client": "^3.3.2",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-endpoints": {
+      "version": "2.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-middleware": {
+      "version": "3.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-retry": {
+      "version": "3.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^3.0.6",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-stream": {
+      "version": "3.1.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^3.2.7",
+        "@smithy/node-http-handler": "^3.2.2",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/bowser": {
+      "version": "2.11.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/@aws-amplify/data-construct/node_modules/charenc": {
       "version": "0.0.2",
@@ -1223,6 +3648,21 @@
         "node": "*"
       }
     },
+    "node_modules/@aws-amplify/data-construct/node_modules/ci-info": {
+      "version": "3.9.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@aws-amplify/data-construct/node_modules/crypt": {
       "version": "0.0.2",
       "dev": true,
@@ -1230,6 +3670,28 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/fs-extra": {
@@ -1246,24 +3708,6 @@
         "node": ">=6 <7 || >=8"
       }
     },
-    "node_modules/@aws-amplify/data-construct/node_modules/fs-extra/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/fs-extra/node_modules/universalify": {
-      "version": "0.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/@aws-amplify/data-construct/node_modules/graceful-fs": {
       "version": "4.2.11",
       "dev": true,
@@ -1271,7 +3715,7 @@
       "license": "ISC"
     },
     "node_modules/@aws-amplify/data-construct/node_modules/graphql": {
-      "version": "15.8.0",
+      "version": "15.9.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -1280,19 +3724,19 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/graphql-mapping-template": {
-      "version": "5.0.0",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/@aws-amplify/data-construct/node_modules/graphql-transformer-common": {
-      "version": "5.0.0",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "graphql": "^15.5.0",
-        "graphql-mapping-template": "5.0.0",
+        "graphql-mapping-template": "5.0.1",
         "md5": "^2.2.1",
         "pluralize": "8.0.0"
       }
@@ -1317,36 +3761,28 @@
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/is-buffer": {
-      "version": "2.0.5",
+      "version": "1.1.6",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
       "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
+      "license": "MIT"
     },
-    "node_modules/@aws-amplify/data-construct/node_modules/jsonfile": {
-      "version": "6.1.0",
+    "node_modules/@aws-amplify/data-construct/node_modules/is-ci": {
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "universalify": "^2.0.0"
+        "ci-info": "^3.2.0"
       },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -1363,6 +3799,12 @@
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/@aws-amplify/data-construct/node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/@aws-amplify/data-construct/node_modules/md5": {
       "version": "2.3.0",
       "dev": true,
@@ -1373,12 +3815,6 @@
         "crypt": "0.0.2",
         "is-buffer": "~1.1.6"
       }
-    },
-    "node_modules/@aws-amplify/data-construct/node_modules/md5/node_modules/is-buffer": {
-      "version": "1.1.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/@aws-amplify/data-construct/node_modules/object-hash": {
       "version": "3.0.0",
@@ -1398,6 +3834,24 @@
         "node": ">=4"
       }
     },
+    "node_modules/@aws-amplify/data-construct/node_modules/semver": {
+      "version": "7.6.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/strnum": {
+      "version": "1.0.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/@aws-amplify/data-construct/node_modules/ts-dedent": {
       "version": "2.2.0",
       "dev": true,
@@ -1407,17 +3861,36 @@
         "node": ">=6.10"
       }
     },
+    "node_modules/@aws-amplify/data-construct/node_modules/tslib": {
+      "version": "2.7.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD"
+    },
     "node_modules/@aws-amplify/data-construct/node_modules/universalify": {
-      "version": "2.0.0",
+      "version": "0.1.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/data-construct/node_modules/uuid": {
+      "version": "9.0.1",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-amplify/data-construct/node_modules/zod": {
-      "version": "3.22.4",
+      "version": "3.23.8",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -1426,30 +3899,32 @@
       }
     },
     "node_modules/@aws-amplify/data-schema": {
-      "version": "1.3.10",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema/-/data-schema-1.3.10.tgz",
-      "integrity": "sha512-rUo6wb+DO6aGCSeSiB8wb92O4cEuN4sZBXn7TgqaYc8Bv4HutrLaIlptgXCYJMkaAp/h9rxyi6wIFJ7bEyD/6g==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema/-/data-schema-1.10.2.tgz",
+      "integrity": "sha512-nsxqyhI5I1PvtUstVoQkoMa9f9MMfqaYRMlpJpeVcw9nL/lt71JTu5C0B1FMFhwB9nC7dNqADh+knuWCLC4HKQ==",
       "dependencies": {
         "@aws-amplify/data-schema-types": "*",
+        "@smithy/util-base64": "^3.0.0",
         "@types/aws-lambda": "^8.10.134",
+        "@types/json-schema": "^7.0.15",
         "rxjs": "^7.8.1"
       }
     },
     "node_modules/@aws-amplify/data-schema-types": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema-types/-/data-schema-types-1.1.1.tgz",
-      "integrity": "sha512-WhWEEsztpSSxIY0lJ3Ge5iA4g3PBm66SQmy1fBH1FBq0T+cxUBijifOU8MNwf+tf6lGpArMX0RS54HRVF5fUSA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema-types/-/data-schema-types-1.2.0.tgz",
+      "integrity": "sha512-1hy2r7jl3hQ5J/CGjhmPhFPcdGSakfme1ZLjlTMJZILfYifZLSlGRKNCelMb3J5N9203hyeT5XDi5yR47JL1TQ==",
       "dependencies": {
         "graphql": "15.8.0",
         "rxjs": "^7.8.1"
       }
     },
     "node_modules/@aws-amplify/datastore": {
-      "version": "5.0.46",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-5.0.46.tgz",
-      "integrity": "sha512-0cVpHyRoXJkxVQwCyS9V5rWBkVP7tliOe9g7jwwiD8NmtcfQPeAcaUDuj2eGjUBgNLAstidJkdjHmMvMi/KyMA==",
+      "version": "5.0.55",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-5.0.55.tgz",
+      "integrity": "sha512-wWupiILAfsinfVzh96CF7PitLLw/aTPie4uvSeWpNqPd7vMfyBMkU5nGHbxIQKong4ZoKo2siHmWX5imzZXWKg==",
       "dependencies": {
-        "@aws-amplify/api": "6.0.46",
+        "@aws-amplify/api": "6.0.55",
         "buffer": "4.9.2",
         "idb": "5.0.6",
         "immer": "9.0.6",
@@ -1461,13 +3936,14 @@
       }
     },
     "node_modules/@aws-amplify/deployed-backend-client": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/deployed-backend-client/-/deployed-backend-client-1.4.0.tgz",
-      "integrity": "sha512-jlmWuJtgDSNG1N/whDOpmbJiZeltcU4UedbQDodSJuXkBgaxsAuRRnJG5YTE5IRwcp/bpsb0py4QsvBUtXkJEg==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/deployed-backend-client/-/deployed-backend-client-1.4.2.tgz",
+      "integrity": "sha512-wfiWWyeJGcHEPu5FxFXJ3ADcePPHnkbqmoG/1tEzzJocI5LBShrSQ/wC/zeQrfZ0GP974BVKDg6CXoOwBNlJMQ==",
       "dev": true,
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.2.0",
         "@aws-amplify/platform-core": "^1.0.5",
+        "@aws-amplify/plugin-types": "^1.2.2",
         "zod": "^3.22.2"
       },
       "peerDependencies": {
@@ -1478,9 +3954,9 @@
       }
     },
     "node_modules/@aws-amplify/form-generator": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/form-generator/-/form-generator-1.0.1.tgz",
-      "integrity": "sha512-3mUqPz2j0F1jwoXbvNtIhbknZR/11dPWsYHJkAYoEFMFOpTNcmukEwG4WjlEGD20/lxbvD5K5lzQ0j+4N/0WTw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/form-generator/-/form-generator-1.0.3.tgz",
+      "integrity": "sha512-KoMAxy2tv1kosKr8wdKd0/+7BdE09iNMVdU8mjon8cTQ6cMwFgO/ds8AdBVqGqRaLWTIVNyThV9nUXgMUjBDQQ==",
       "dev": true,
       "dependencies": {
         "@aws-amplify/appsync-modelgen-plugin": "^2.11.0",
@@ -1499,16 +3975,18 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-api-construct/-/graphql-api-construct-1.11.6.tgz",
-      "integrity": "sha512-5QeTPio8invyp9LyOyHdhJ2G1zIW1EzQ13pKN2xX8VcAAUdiG9coYgDUUK0CaKnvMuhhknter1oinxZh5I3ngw==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-api-construct/-/graphql-api-construct-1.15.1.tgz",
+      "integrity": "sha512-hhQBufGDLgU6ihHpp8PWO9D0aQYJKXSngyv6VL+we5axKZQnCZiw8XrGrh4xq97W+olMUhfmwLRAw+N0Xd2Bpg==",
       "bundleDependencies": [
         "@aws-amplify/backend-output-schemas",
         "@aws-amplify/backend-output-storage",
         "@aws-amplify/graphql-auth-transformer",
+        "@aws-amplify/graphql-conversation-transformer",
         "@aws-amplify/graphql-default-value-transformer",
         "@aws-amplify/graphql-directives",
         "@aws-amplify/graphql-function-transformer",
+        "@aws-amplify/graphql-generation-transformer",
         "@aws-amplify/graphql-http-transformer",
         "@aws-amplify/graphql-index-transformer",
         "@aws-amplify/graphql-maps-to-transformer",
@@ -1522,6 +4000,14 @@
         "@aws-amplify/graphql-transformer-interfaces",
         "@aws-amplify/platform-core",
         "@aws-amplify/plugin-types",
+        "@aws-amplify/ai-constructs",
+        "@aws-sdk/client-bedrock-runtime",
+        "@smithy/eventstream-serde-browser",
+        "@smithy/eventstream-serde-config-resolver",
+        "@smithy/eventstream-serde-node",
+        "@smithy/eventstream-serde-universal",
+        "@smithy/eventstream-codec",
+        "@aws-crypto/crc32",
         "charenc",
         "crypt",
         "fs-extra",
@@ -1540,323 +4026,541 @@
         "pluralize",
         "ts-dedent",
         "universalify",
-        "zod"
+        "zod",
+        "@aws-sdk/client-sts",
+        "is-ci",
+        "lodash.mergewith",
+        "uuid",
+        "@aws-crypto/sha256-browser",
+        "@aws-crypto/sha256-js",
+        "@aws-sdk/client-sso-oidc",
+        "@aws-sdk/core",
+        "@aws-sdk/credential-provider-node",
+        "@aws-sdk/middleware-host-header",
+        "@aws-sdk/middleware-logger",
+        "@aws-sdk/middleware-recursion-detection",
+        "@aws-sdk/middleware-user-agent",
+        "@aws-sdk/region-config-resolver",
+        "@aws-sdk/types",
+        "@aws-sdk/util-endpoints",
+        "@aws-sdk/util-user-agent-browser",
+        "@aws-sdk/util-user-agent-node",
+        "@smithy/config-resolver",
+        "@smithy/core",
+        "@smithy/fetch-http-handler",
+        "@smithy/hash-node",
+        "@smithy/invalid-dependency",
+        "@smithy/middleware-content-length",
+        "@smithy/middleware-endpoint",
+        "@smithy/middleware-retry",
+        "@smithy/middleware-serde",
+        "@smithy/middleware-stack",
+        "@smithy/node-config-provider",
+        "@smithy/node-http-handler",
+        "@smithy/protocol-http",
+        "@smithy/smithy-client",
+        "@smithy/types",
+        "@smithy/url-parser",
+        "@smithy/util-base64",
+        "@smithy/util-body-length-browser",
+        "@smithy/util-body-length-node",
+        "@smithy/util-defaults-mode-browser",
+        "@smithy/util-defaults-mode-node",
+        "@smithy/util-endpoints",
+        "@smithy/util-middleware",
+        "@smithy/util-retry",
+        "@smithy/util-utf8",
+        "tslib",
+        "ci-info",
+        "@aws-crypto/supports-web-crypto",
+        "@aws-crypto/util",
+        "@aws-sdk/util-locate-window",
+        "@smithy/signature-v4",
+        "fast-xml-parser",
+        "@aws-sdk/credential-provider-env",
+        "@aws-sdk/credential-provider-http",
+        "@aws-sdk/credential-provider-ini",
+        "@aws-sdk/credential-provider-process",
+        "@aws-sdk/credential-provider-sso",
+        "@aws-sdk/credential-provider-web-identity",
+        "@smithy/credential-provider-imds",
+        "@smithy/property-provider",
+        "@smithy/shared-ini-file-loader",
+        "@smithy/util-config-provider",
+        "bowser",
+        "@smithy/querystring-builder",
+        "@smithy/util-buffer-from",
+        "@smithy/service-error-classification",
+        "@smithy/abort-controller",
+        "@smithy/util-stream",
+        "@smithy/querystring-parser",
+        "@smithy/is-array-buffer",
+        "@smithy/util-hex-encoding",
+        "@smithy/util-uri-escape",
+        "strnum",
+        "@aws-sdk/token-providers",
+        "@aws-sdk/client-sso",
+        "semver"
       ],
       "dev": true,
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.4.0",
-        "@aws-amplify/backend-output-storage": "^0.2.2",
-        "@aws-amplify/graphql-auth-transformer": "4.0.0",
-        "@aws-amplify/graphql-default-value-transformer": "3.0.0",
-        "@aws-amplify/graphql-directives": "2.0.0",
-        "@aws-amplify/graphql-function-transformer": "3.0.0",
-        "@aws-amplify/graphql-http-transformer": "3.0.0",
-        "@aws-amplify/graphql-index-transformer": "3.0.0",
-        "@aws-amplify/graphql-maps-to-transformer": "4.0.0",
-        "@aws-amplify/graphql-model-transformer": "3.0.0",
-        "@aws-amplify/graphql-predictions-transformer": "3.0.0",
-        "@aws-amplify/graphql-relational-transformer": "3.0.0",
-        "@aws-amplify/graphql-searchable-transformer": "3.0.0",
-        "@aws-amplify/graphql-sql-transformer": "0.4.0",
-        "@aws-amplify/graphql-transformer": "2.0.0",
-        "@aws-amplify/graphql-transformer-core": "3.0.0",
-        "@aws-amplify/graphql-transformer-interfaces": "4.0.0",
-        "@aws-amplify/platform-core": "^0.2.0",
-        "@aws-amplify/plugin-types": "^0.4.1",
+        "@aws-amplify/ai-constructs": "^0.2.0",
+        "@aws-amplify/backend-output-schemas": "^1.0.0",
+        "@aws-amplify/backend-output-storage": "^1.0.0",
+        "@aws-amplify/graphql-auth-transformer": "4.1.4",
+        "@aws-amplify/graphql-conversation-transformer": "0.4.0",
+        "@aws-amplify/graphql-default-value-transformer": "3.1.1",
+        "@aws-amplify/graphql-directives": "2.4.0",
+        "@aws-amplify/graphql-function-transformer": "3.1.3",
+        "@aws-amplify/graphql-generation-transformer": "0.2.4",
+        "@aws-amplify/graphql-http-transformer": "3.0.6",
+        "@aws-amplify/graphql-index-transformer": "3.0.6",
+        "@aws-amplify/graphql-maps-to-transformer": "4.0.6",
+        "@aws-amplify/graphql-model-transformer": "3.0.6",
+        "@aws-amplify/graphql-predictions-transformer": "3.0.6",
+        "@aws-amplify/graphql-relational-transformer": "3.0.6",
+        "@aws-amplify/graphql-searchable-transformer": "3.0.6",
+        "@aws-amplify/graphql-sql-transformer": "0.4.6",
+        "@aws-amplify/graphql-transformer": "2.1.4",
+        "@aws-amplify/graphql-transformer-core": "3.2.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.1.2",
+        "@aws-amplify/platform-core": "^1.0.0",
+        "@aws-amplify/plugin-types": "^1.0.0",
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.622.0",
+        "@aws-sdk/client-sso": "3.637.0",
+        "@aws-sdk/client-sso-oidc": "3.637.0",
+        "@aws-sdk/client-sts": "^3.624.0",
+        "@aws-sdk/core": "3.635.0",
+        "@aws-sdk/credential-provider-env": "3.620.1",
+        "@aws-sdk/credential-provider-http": "3.635.0",
+        "@aws-sdk/credential-provider-ini": "3.637.0",
+        "@aws-sdk/credential-provider-node": "3.637.0",
+        "@aws-sdk/credential-provider-process": "3.620.1",
+        "@aws-sdk/credential-provider-sso": "3.637.0",
+        "@aws-sdk/credential-provider-web-identity": "3.621.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.637.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/token-providers": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.637.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/abort-controller": "^3.1.1",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.4.0",
+        "@smithy/credential-provider-imds": "^3.2.0",
+        "@smithy/eventstream-codec": "^3.1.2",
+        "@smithy/eventstream-serde-browser": "^3.0.6",
+        "@smithy/eventstream-serde-config-resolver": "^3.0.3",
+        "@smithy/eventstream-serde-node": "^3.0.5",
+        "@smithy/eventstream-serde-universal": "^3.0.5",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.15",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/querystring-builder": "^3.0.3",
+        "@smithy/querystring-parser": "^3.0.3",
+        "@smithy/service-error-classification": "^3.0.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/signature-v4": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.15",
+        "@smithy/util-defaults-mode-node": "^3.0.15",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-stream": "^3.1.3",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "bowser": "^2.11.0",
         "charenc": "^0.0.2",
+        "ci-info": "^3.2.0",
         "crypt": "^0.0.2",
+        "fast-xml-parser": "4.4.1",
         "fs-extra": "^8.1.0",
-        "graceful-fs": "^4.2.11",
+        "graceful-fs": "^4.2.0",
         "graphql": "^15.5.0",
-        "graphql-mapping-template": "5.0.0",
-        "graphql-transformer-common": "5.0.0",
+        "graphql-mapping-template": "5.0.1",
+        "graphql-transformer-common": "5.0.1",
         "hjson": "^3.2.2",
         "immer": "^9.0.12",
-        "is-buffer": "^2.0.5",
-        "jsonfile": "^6.1.0",
+        "is-buffer": "~1.1.6",
+        "is-ci": "^3.0.1",
+        "jsonfile": "^4.0.0",
         "libphonenumber-js": "1.9.47",
         "lodash": "^4.17.21",
-        "md5": "^2.3.0",
+        "lodash.mergewith": "^4.6.2",
+        "md5": "^2.2.1",
         "object-hash": "^3.0.0",
-        "pluralize": "^8.0.0",
+        "pluralize": "8.0.0",
+        "semver": "^7.6.3",
+        "strnum": "^1.0.5",
         "ts-dedent": "^2.0.0",
-        "universalify": "^2.0.0",
-        "zod": "^3.22.3"
+        "tslib": "^2.6.2",
+        "universalify": "^0.1.0",
+        "uuid": "^9.0.1",
+        "zod": "^3.22.2"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.129.0",
+        "aws-cdk-lib": "^2.158.0",
         "constructs": "^10.3.0"
       }
     },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/ai-constructs": {
+      "version": "0.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/plugin-types": "^1.0.1",
+        "@aws-sdk/client-bedrock-runtime": "^3.622.0",
+        "@smithy/types": "^3.3.0"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.152.0",
+        "constructs": "^10.0.0"
+      }
+    },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/backend-output-schemas": {
-      "version": "0.4.0",
+      "version": "1.2.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "peerDependencies": {
-        "zod": "^3.21.4"
+        "zod": "^3.22.2"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/backend-output-storage": {
-      "version": "0.2.2",
+      "version": "1.1.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/backend-output-schemas": "^0.4.0",
-        "@aws-amplify/platform-core": "^0.2.0"
+        "@aws-amplify/backend-output-schemas": "^1.2.0",
+        "@aws-amplify/platform-core": "^1.0.6"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.103.0"
+        "aws-cdk-lib": "^2.152.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-auth-transformer": {
-      "version": "4.0.0",
+      "version": "4.1.4",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.0.0",
-        "@aws-amplify/graphql-model-transformer": "3.0.0",
-        "@aws-amplify/graphql-relational-transformer": "3.0.0",
-        "@aws-amplify/graphql-transformer-core": "3.0.0",
-        "@aws-amplify/graphql-transformer-interfaces": "4.0.0",
+        "@aws-amplify/graphql-directives": "2.4.0",
+        "@aws-amplify/graphql-model-transformer": "3.0.6",
+        "@aws-amplify/graphql-relational-transformer": "3.0.6",
+        "@aws-amplify/graphql-transformer-core": "3.2.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.1.2",
         "graphql": "^15.5.0",
-        "graphql-mapping-template": "5.0.0",
-        "graphql-transformer-common": "5.0.0",
+        "graphql-mapping-template": "5.0.1",
+        "graphql-transformer-common": "5.0.1",
         "lodash": "^4.17.21",
         "md5": "^2.3.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.129.0",
+        "aws-cdk-lib": "^2.158.0",
         "constructs": "^10.3.0"
       }
     },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-default-value-transformer": {
-      "version": "3.0.0",
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-conversation-transformer": {
+      "version": "0.4.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.0.0",
-        "@aws-amplify/graphql-transformer-core": "3.0.0",
-        "@aws-amplify/graphql-transformer-interfaces": "4.0.0",
+        "@aws-amplify/ai-constructs": "^0.2.0",
+        "@aws-amplify/graphql-directives": "2.4.0",
+        "@aws-amplify/graphql-index-transformer": "3.0.6",
+        "@aws-amplify/graphql-model-transformer": "3.0.6",
+        "@aws-amplify/graphql-relational-transformer": "3.0.6",
+        "@aws-amplify/graphql-transformer-core": "3.2.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.1.2",
         "graphql": "^15.5.0",
-        "graphql-mapping-template": "5.0.0",
-        "graphql-transformer-common": "5.0.0",
+        "graphql-mapping-template": "5.0.1",
+        "graphql-transformer-common": "5.0.1",
+        "immer": "^9.0.12",
+        "semver": "^7.6.3"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.158.0",
+        "constructs": "^10.3.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-default-value-transformer": {
+      "version": "3.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/graphql-directives": "2.4.0",
+        "@aws-amplify/graphql-transformer-core": "3.2.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.1.2",
+        "graphql": "^15.5.0",
+        "graphql-mapping-template": "5.0.1",
+        "graphql-transformer-common": "5.0.1",
         "libphonenumber-js": "1.9.47"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-directives": {
-      "version": "2.0.0",
+      "version": "2.4.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-function-transformer": {
-      "version": "3.0.0",
+      "version": "3.1.3",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.0.0",
-        "@aws-amplify/graphql-transformer-core": "3.0.0",
-        "@aws-amplify/graphql-transformer-interfaces": "4.0.0",
+        "@aws-amplify/graphql-directives": "2.4.0",
+        "@aws-amplify/graphql-transformer-core": "3.2.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.1.2",
         "graphql": "^15.5.0",
-        "graphql-mapping-template": "5.0.0",
-        "graphql-transformer-common": "5.0.0"
+        "graphql-mapping-template": "5.0.1",
+        "graphql-transformer-common": "5.0.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.129.0",
+        "aws-cdk-lib": "^2.158.0",
+        "constructs": "^10.3.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-generation-transformer": {
+      "version": "0.2.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-amplify/graphql-directives": "2.4.0",
+        "@aws-amplify/graphql-transformer-core": "3.2.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.1.2",
+        "graphql": "^15.5.0",
+        "graphql-mapping-template": "5.0.1",
+        "graphql-transformer-common": "5.0.1",
+        "immer": "^9.0.12"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.158.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-http-transformer": {
-      "version": "3.0.0",
+      "version": "3.0.6",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.0.0",
-        "@aws-amplify/graphql-transformer-core": "3.0.0",
-        "@aws-amplify/graphql-transformer-interfaces": "4.0.0",
+        "@aws-amplify/graphql-directives": "2.4.0",
+        "@aws-amplify/graphql-transformer-core": "3.2.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.1.2",
         "graphql": "^15.5.0",
-        "graphql-mapping-template": "5.0.0",
-        "graphql-transformer-common": "5.0.0"
+        "graphql-mapping-template": "5.0.1",
+        "graphql-transformer-common": "5.0.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.129.0",
+        "aws-cdk-lib": "^2.158.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-index-transformer": {
-      "version": "3.0.0",
+      "version": "3.0.6",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.0.0",
-        "@aws-amplify/graphql-model-transformer": "3.0.0",
-        "@aws-amplify/graphql-transformer-core": "3.0.0",
-        "@aws-amplify/graphql-transformer-interfaces": "4.0.0",
+        "@aws-amplify/graphql-directives": "2.4.0",
+        "@aws-amplify/graphql-model-transformer": "3.0.6",
+        "@aws-amplify/graphql-transformer-core": "3.2.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.1.2",
         "graphql": "^15.5.0",
-        "graphql-mapping-template": "5.0.0",
-        "graphql-transformer-common": "5.0.0"
+        "graphql-mapping-template": "5.0.1",
+        "graphql-transformer-common": "5.0.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.129.0",
+        "aws-cdk-lib": "^2.158.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-maps-to-transformer": {
-      "version": "4.0.0",
+      "version": "4.0.6",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.0.0",
-        "@aws-amplify/graphql-transformer-core": "3.0.0",
-        "@aws-amplify/graphql-transformer-interfaces": "4.0.0",
-        "graphql-mapping-template": "5.0.0",
-        "graphql-transformer-common": "5.0.0"
+        "@aws-amplify/graphql-directives": "2.4.0",
+        "@aws-amplify/graphql-transformer-core": "3.2.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.1.2",
+        "graphql-mapping-template": "5.0.1",
+        "graphql-transformer-common": "5.0.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.129.0",
+        "aws-cdk-lib": "^2.158.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-model-transformer": {
-      "version": "3.0.0",
+      "version": "3.0.6",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.0.0",
-        "@aws-amplify/graphql-transformer-core": "3.0.0",
-        "@aws-amplify/graphql-transformer-interfaces": "4.0.0",
+        "@aws-amplify/graphql-directives": "2.4.0",
+        "@aws-amplify/graphql-transformer-core": "3.2.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.1.2",
         "graphql": "^15.5.0",
-        "graphql-mapping-template": "5.0.0",
-        "graphql-transformer-common": "5.0.0"
+        "graphql-mapping-template": "5.0.1",
+        "graphql-transformer-common": "5.0.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.129.0",
+        "aws-cdk-lib": "^2.158.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-predictions-transformer": {
-      "version": "3.0.0",
+      "version": "3.0.6",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.0.0",
-        "@aws-amplify/graphql-transformer-core": "3.0.0",
-        "@aws-amplify/graphql-transformer-interfaces": "4.0.0",
+        "@aws-amplify/graphql-directives": "2.4.0",
+        "@aws-amplify/graphql-transformer-core": "3.2.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.1.2",
         "graphql": "^15.5.0",
-        "graphql-mapping-template": "5.0.0",
-        "graphql-transformer-common": "5.0.0"
+        "graphql-mapping-template": "5.0.1",
+        "graphql-transformer-common": "5.0.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.129.0",
+        "aws-cdk-lib": "^2.158.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-relational-transformer": {
-      "version": "3.0.0",
+      "version": "3.0.6",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.0.0",
-        "@aws-amplify/graphql-index-transformer": "3.0.0",
-        "@aws-amplify/graphql-model-transformer": "3.0.0",
-        "@aws-amplify/graphql-transformer-core": "3.0.0",
-        "@aws-amplify/graphql-transformer-interfaces": "4.0.0",
+        "@aws-amplify/graphql-directives": "2.4.0",
+        "@aws-amplify/graphql-index-transformer": "3.0.6",
+        "@aws-amplify/graphql-model-transformer": "3.0.6",
+        "@aws-amplify/graphql-transformer-core": "3.2.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.1.2",
         "graphql": "^15.5.0",
-        "graphql-mapping-template": "5.0.0",
-        "graphql-transformer-common": "5.0.0",
+        "graphql-mapping-template": "5.0.1",
+        "graphql-transformer-common": "5.0.1",
         "immer": "^9.0.12"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.129.0",
+        "aws-cdk-lib": "^2.158.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-searchable-transformer": {
-      "version": "3.0.0",
+      "version": "3.0.6",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.0.0",
-        "@aws-amplify/graphql-model-transformer": "3.0.0",
-        "@aws-amplify/graphql-transformer-core": "3.0.0",
-        "@aws-amplify/graphql-transformer-interfaces": "4.0.0",
+        "@aws-amplify/graphql-directives": "2.4.0",
+        "@aws-amplify/graphql-model-transformer": "3.0.6",
+        "@aws-amplify/graphql-transformer-core": "3.2.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.1.2",
         "graphql": "^15.5.0",
-        "graphql-mapping-template": "5.0.0",
-        "graphql-transformer-common": "5.0.0"
+        "graphql-mapping-template": "5.0.1",
+        "graphql-transformer-common": "5.0.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.129.0",
+        "aws-cdk-lib": "^2.158.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-sql-transformer": {
-      "version": "0.4.0",
+      "version": "0.4.6",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.0.0",
-        "@aws-amplify/graphql-model-transformer": "3.0.0",
-        "@aws-amplify/graphql-transformer-core": "3.0.0",
-        "@aws-amplify/graphql-transformer-interfaces": "4.0.0",
+        "@aws-amplify/graphql-directives": "2.4.0",
+        "@aws-amplify/graphql-model-transformer": "3.0.6",
+        "@aws-amplify/graphql-transformer-core": "3.2.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.1.2",
         "graphql": "^15.5.0",
-        "graphql-mapping-template": "5.0.0",
-        "graphql-transformer-common": "5.0.0"
+        "graphql-mapping-template": "5.0.1",
+        "graphql-transformer-common": "5.0.1"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.129.0",
+        "aws-cdk-lib": "^2.158.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer": {
-      "version": "2.0.0",
+      "version": "2.1.4",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-auth-transformer": "4.0.0",
-        "@aws-amplify/graphql-default-value-transformer": "3.0.0",
-        "@aws-amplify/graphql-function-transformer": "3.0.0",
-        "@aws-amplify/graphql-http-transformer": "3.0.0",
-        "@aws-amplify/graphql-index-transformer": "3.0.0",
-        "@aws-amplify/graphql-maps-to-transformer": "4.0.0",
-        "@aws-amplify/graphql-model-transformer": "3.0.0",
-        "@aws-amplify/graphql-predictions-transformer": "3.0.0",
-        "@aws-amplify/graphql-relational-transformer": "3.0.0",
-        "@aws-amplify/graphql-searchable-transformer": "3.0.0",
-        "@aws-amplify/graphql-sql-transformer": "0.4.0",
-        "@aws-amplify/graphql-transformer-core": "3.0.0",
-        "@aws-amplify/graphql-transformer-interfaces": "4.0.0"
+        "@aws-amplify/graphql-auth-transformer": "4.1.4",
+        "@aws-amplify/graphql-conversation-transformer": "0.4.0",
+        "@aws-amplify/graphql-default-value-transformer": "3.1.1",
+        "@aws-amplify/graphql-function-transformer": "3.1.3",
+        "@aws-amplify/graphql-generation-transformer": "0.2.4",
+        "@aws-amplify/graphql-http-transformer": "3.0.6",
+        "@aws-amplify/graphql-index-transformer": "3.0.6",
+        "@aws-amplify/graphql-maps-to-transformer": "4.0.6",
+        "@aws-amplify/graphql-model-transformer": "3.0.6",
+        "@aws-amplify/graphql-predictions-transformer": "3.0.6",
+        "@aws-amplify/graphql-relational-transformer": "3.0.6",
+        "@aws-amplify/graphql-searchable-transformer": "3.0.6",
+        "@aws-amplify/graphql-sql-transformer": "0.4.6",
+        "@aws-amplify/graphql-transformer-core": "3.2.1",
+        "@aws-amplify/graphql-transformer-interfaces": "4.1.2"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.129.0",
+        "aws-cdk-lib": "^2.158.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer-core": {
-      "version": "3.0.0",
+      "version": "3.2.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-directives": "2.0.0",
-        "@aws-amplify/graphql-transformer-interfaces": "4.0.0",
+        "@aws-amplify/graphql-directives": "2.4.0",
+        "@aws-amplify/graphql-transformer-interfaces": "4.1.2",
         "fs-extra": "^8.1.0",
         "graphql": "^15.5.0",
-        "graphql-mapping-template": "5.0.0",
-        "graphql-transformer-common": "5.0.0",
+        "graphql-mapping-template": "5.0.1",
+        "graphql-transformer-common": "5.0.1",
         "hjson": "^3.2.2",
         "lodash": "^4.17.21",
         "md5": "^2.3.0",
@@ -1864,12 +4568,12 @@
         "ts-dedent": "^2.0.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.129.0",
+        "aws-cdk-lib": "^2.158.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/graphql-transformer-interfaces": {
-      "version": "4.0.0",
+      "version": "4.1.2",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -1877,28 +4581,2222 @@
         "graphql": "^15.5.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.129.0",
+        "aws-cdk-lib": "^2.158.0",
         "constructs": "^10.3.0"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/platform-core": {
-      "version": "0.2.0",
+      "version": "1.1.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/plugin-types": "^0.4.0"
+        "@aws-amplify/plugin-types": "^1.2.1",
+        "@aws-sdk/client-sts": "^3.624.0",
+        "is-ci": "^3.0.1",
+        "lodash.mergewith": "^4.6.2",
+        "semver": "^7.6.3",
+        "uuid": "^9.0.1",
+        "zod": "^3.22.2"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-amplify/plugin-types": {
-      "version": "0.4.1",
+      "version": "1.2.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "peerDependencies": {
-        "aws-cdk-lib": "^2.103.0",
+        "@aws-sdk/types": "^3.609.0",
+        "aws-cdk-lib": "^2.152.0",
         "constructs": "^10.0.0"
       }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/crc32/node_modules/@aws-sdk/types": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/sha256-browser/node_modules/@aws-sdk/types": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/sha256-js/node_modules/@aws-sdk/types": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/util/node_modules/@aws-sdk/types": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.651.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.651.1",
+        "@aws-sdk/client-sts": "3.651.1",
+        "@aws-sdk/core": "3.651.1",
+        "@aws-sdk/credential-provider-node": "3.651.1",
+        "@aws-sdk/middleware-host-header": "3.649.0",
+        "@aws-sdk/middleware-logger": "3.649.0",
+        "@aws-sdk/middleware-recursion-detection": "3.649.0",
+        "@aws-sdk/middleware-user-agent": "3.649.0",
+        "@aws-sdk/region-config-resolver": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@aws-sdk/util-endpoints": "3.649.0",
+        "@aws-sdk/util-user-agent-browser": "3.649.0",
+        "@aws-sdk/util-user-agent-node": "3.649.0",
+        "@smithy/config-resolver": "^3.0.6",
+        "@smithy/core": "^2.4.1",
+        "@smithy/eventstream-serde-browser": "^3.0.7",
+        "@smithy/eventstream-serde-config-resolver": "^3.0.4",
+        "@smithy/eventstream-serde-node": "^3.0.6",
+        "@smithy/fetch-http-handler": "^3.2.5",
+        "@smithy/hash-node": "^3.0.4",
+        "@smithy/invalid-dependency": "^3.0.4",
+        "@smithy/middleware-content-length": "^3.0.6",
+        "@smithy/middleware-endpoint": "^3.1.1",
+        "@smithy/middleware-retry": "^3.0.16",
+        "@smithy/middleware-serde": "^3.0.4",
+        "@smithy/middleware-stack": "^3.0.4",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/node-http-handler": "^3.2.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/smithy-client": "^3.3.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/url-parser": "^3.0.4",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.16",
+        "@smithy/util-defaults-mode-node": "^3.0.16",
+        "@smithy/util-endpoints": "^2.1.0",
+        "@smithy/util-middleware": "^3.0.4",
+        "@smithy/util-retry": "^3.0.4",
+        "@smithy/util-stream": "^3.1.4",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/client-sso": {
+      "version": "3.651.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.651.1",
+        "@aws-sdk/middleware-host-header": "3.649.0",
+        "@aws-sdk/middleware-logger": "3.649.0",
+        "@aws-sdk/middleware-recursion-detection": "3.649.0",
+        "@aws-sdk/middleware-user-agent": "3.649.0",
+        "@aws-sdk/region-config-resolver": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@aws-sdk/util-endpoints": "3.649.0",
+        "@aws-sdk/util-user-agent-browser": "3.649.0",
+        "@aws-sdk/util-user-agent-node": "3.649.0",
+        "@smithy/config-resolver": "^3.0.6",
+        "@smithy/core": "^2.4.1",
+        "@smithy/fetch-http-handler": "^3.2.5",
+        "@smithy/hash-node": "^3.0.4",
+        "@smithy/invalid-dependency": "^3.0.4",
+        "@smithy/middleware-content-length": "^3.0.6",
+        "@smithy/middleware-endpoint": "^3.1.1",
+        "@smithy/middleware-retry": "^3.0.16",
+        "@smithy/middleware-serde": "^3.0.4",
+        "@smithy/middleware-stack": "^3.0.4",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/node-http-handler": "^3.2.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/smithy-client": "^3.3.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/url-parser": "^3.0.4",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.16",
+        "@smithy/util-defaults-mode-node": "^3.0.16",
+        "@smithy/util-endpoints": "^2.1.0",
+        "@smithy/util-middleware": "^3.0.4",
+        "@smithy/util-retry": "^3.0.4",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.651.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.651.1",
+        "@aws-sdk/credential-provider-node": "3.651.1",
+        "@aws-sdk/middleware-host-header": "3.649.0",
+        "@aws-sdk/middleware-logger": "3.649.0",
+        "@aws-sdk/middleware-recursion-detection": "3.649.0",
+        "@aws-sdk/middleware-user-agent": "3.649.0",
+        "@aws-sdk/region-config-resolver": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@aws-sdk/util-endpoints": "3.649.0",
+        "@aws-sdk/util-user-agent-browser": "3.649.0",
+        "@aws-sdk/util-user-agent-node": "3.649.0",
+        "@smithy/config-resolver": "^3.0.6",
+        "@smithy/core": "^2.4.1",
+        "@smithy/fetch-http-handler": "^3.2.5",
+        "@smithy/hash-node": "^3.0.4",
+        "@smithy/invalid-dependency": "^3.0.4",
+        "@smithy/middleware-content-length": "^3.0.6",
+        "@smithy/middleware-endpoint": "^3.1.1",
+        "@smithy/middleware-retry": "^3.0.16",
+        "@smithy/middleware-serde": "^3.0.4",
+        "@smithy/middleware-stack": "^3.0.4",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/node-http-handler": "^3.2.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/smithy-client": "^3.3.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/url-parser": "^3.0.4",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.16",
+        "@smithy/util-defaults-mode-node": "^3.0.16",
+        "@smithy/util-endpoints": "^2.1.0",
+        "@smithy/util-middleware": "^3.0.4",
+        "@smithy/util-retry": "^3.0.4",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.651.1"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/core": {
+      "version": "3.651.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^2.4.1",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/signature-v4": "^4.1.1",
+        "@smithy/smithy-client": "^3.3.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/util-middleware": "^3.0.4",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/fetch-http-handler": "^3.2.5",
+        "@smithy/node-http-handler": "^3.2.0",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/smithy-client": "^3.3.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/util-stream": "^3.1.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.651.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.649.0",
+        "@aws-sdk/credential-provider-http": "3.649.0",
+        "@aws-sdk/credential-provider-process": "3.649.0",
+        "@aws-sdk/credential-provider-sso": "3.651.1",
+        "@aws-sdk/credential-provider-web-identity": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/credential-provider-imds": "^3.2.1",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.5",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.651.1"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.651.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.649.0",
+        "@aws-sdk/credential-provider-http": "3.649.0",
+        "@aws-sdk/credential-provider-ini": "3.651.1",
+        "@aws-sdk/credential-provider-process": "3.649.0",
+        "@aws-sdk/credential-provider-sso": "3.651.1",
+        "@aws-sdk/credential-provider-web-identity": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/credential-provider-imds": "^3.2.1",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.5",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.5",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.651.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.651.1",
+        "@aws-sdk/token-providers": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.5",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.649.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@aws-sdk/util-endpoints": "3.649.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/types": "^3.4.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/token-providers": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.5",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.649.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/types": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/util-endpoints": "^2.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/types": "^3.4.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sso": {
+      "version": "3.637.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.635.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.637.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.637.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.4.0",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.15",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.15",
+        "@smithy/util-defaults-mode-node": "^3.0.15",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.637.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.635.0",
+        "@aws-sdk/credential-provider-node": "3.637.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
+        "@aws-sdk/middleware-logger": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.637.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.637.0",
+        "@aws-sdk/util-user-agent-browser": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.4.0",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/hash-node": "^3.0.3",
+        "@smithy/invalid-dependency": "^3.0.3",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.15",
+        "@smithy/middleware-serde": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.15",
+        "@smithy/util-defaults-mode-node": "^3.0.15",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.637.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts": {
+      "version": "3.651.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.651.1",
+        "@aws-sdk/core": "3.651.1",
+        "@aws-sdk/credential-provider-node": "3.651.1",
+        "@aws-sdk/middleware-host-header": "3.649.0",
+        "@aws-sdk/middleware-logger": "3.649.0",
+        "@aws-sdk/middleware-recursion-detection": "3.649.0",
+        "@aws-sdk/middleware-user-agent": "3.649.0",
+        "@aws-sdk/region-config-resolver": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@aws-sdk/util-endpoints": "3.649.0",
+        "@aws-sdk/util-user-agent-browser": "3.649.0",
+        "@aws-sdk/util-user-agent-node": "3.649.0",
+        "@smithy/config-resolver": "^3.0.6",
+        "@smithy/core": "^2.4.1",
+        "@smithy/fetch-http-handler": "^3.2.5",
+        "@smithy/hash-node": "^3.0.4",
+        "@smithy/invalid-dependency": "^3.0.4",
+        "@smithy/middleware-content-length": "^3.0.6",
+        "@smithy/middleware-endpoint": "^3.1.1",
+        "@smithy/middleware-retry": "^3.0.16",
+        "@smithy/middleware-serde": "^3.0.4",
+        "@smithy/middleware-stack": "^3.0.4",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/node-http-handler": "^3.2.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/smithy-client": "^3.3.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/url-parser": "^3.0.4",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.16",
+        "@smithy/util-defaults-mode-node": "^3.0.16",
+        "@smithy/util-endpoints": "^2.1.0",
+        "@smithy/util-middleware": "^3.0.4",
+        "@smithy/util-retry": "^3.0.4",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/client-sso": {
+      "version": "3.651.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.651.1",
+        "@aws-sdk/middleware-host-header": "3.649.0",
+        "@aws-sdk/middleware-logger": "3.649.0",
+        "@aws-sdk/middleware-recursion-detection": "3.649.0",
+        "@aws-sdk/middleware-user-agent": "3.649.0",
+        "@aws-sdk/region-config-resolver": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@aws-sdk/util-endpoints": "3.649.0",
+        "@aws-sdk/util-user-agent-browser": "3.649.0",
+        "@aws-sdk/util-user-agent-node": "3.649.0",
+        "@smithy/config-resolver": "^3.0.6",
+        "@smithy/core": "^2.4.1",
+        "@smithy/fetch-http-handler": "^3.2.5",
+        "@smithy/hash-node": "^3.0.4",
+        "@smithy/invalid-dependency": "^3.0.4",
+        "@smithy/middleware-content-length": "^3.0.6",
+        "@smithy/middleware-endpoint": "^3.1.1",
+        "@smithy/middleware-retry": "^3.0.16",
+        "@smithy/middleware-serde": "^3.0.4",
+        "@smithy/middleware-stack": "^3.0.4",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/node-http-handler": "^3.2.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/smithy-client": "^3.3.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/url-parser": "^3.0.4",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.16",
+        "@smithy/util-defaults-mode-node": "^3.0.16",
+        "@smithy/util-endpoints": "^2.1.0",
+        "@smithy/util-middleware": "^3.0.4",
+        "@smithy/util-retry": "^3.0.4",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.651.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.651.1",
+        "@aws-sdk/credential-provider-node": "3.651.1",
+        "@aws-sdk/middleware-host-header": "3.649.0",
+        "@aws-sdk/middleware-logger": "3.649.0",
+        "@aws-sdk/middleware-recursion-detection": "3.649.0",
+        "@aws-sdk/middleware-user-agent": "3.649.0",
+        "@aws-sdk/region-config-resolver": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@aws-sdk/util-endpoints": "3.649.0",
+        "@aws-sdk/util-user-agent-browser": "3.649.0",
+        "@aws-sdk/util-user-agent-node": "3.649.0",
+        "@smithy/config-resolver": "^3.0.6",
+        "@smithy/core": "^2.4.1",
+        "@smithy/fetch-http-handler": "^3.2.5",
+        "@smithy/hash-node": "^3.0.4",
+        "@smithy/invalid-dependency": "^3.0.4",
+        "@smithy/middleware-content-length": "^3.0.6",
+        "@smithy/middleware-endpoint": "^3.1.1",
+        "@smithy/middleware-retry": "^3.0.16",
+        "@smithy/middleware-serde": "^3.0.4",
+        "@smithy/middleware-stack": "^3.0.4",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/node-http-handler": "^3.2.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/smithy-client": "^3.3.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/url-parser": "^3.0.4",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.16",
+        "@smithy/util-defaults-mode-node": "^3.0.16",
+        "@smithy/util-endpoints": "^2.1.0",
+        "@smithy/util-middleware": "^3.0.4",
+        "@smithy/util-retry": "^3.0.4",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.651.1"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/core": {
+      "version": "3.651.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^2.4.1",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/signature-v4": "^4.1.1",
+        "@smithy/smithy-client": "^3.3.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/util-middleware": "^3.0.4",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/fetch-http-handler": "^3.2.5",
+        "@smithy/node-http-handler": "^3.2.0",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/smithy-client": "^3.3.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/util-stream": "^3.1.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.651.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.649.0",
+        "@aws-sdk/credential-provider-http": "3.649.0",
+        "@aws-sdk/credential-provider-process": "3.649.0",
+        "@aws-sdk/credential-provider-sso": "3.651.1",
+        "@aws-sdk/credential-provider-web-identity": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/credential-provider-imds": "^3.2.1",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.5",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.651.1"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.651.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.649.0",
+        "@aws-sdk/credential-provider-http": "3.649.0",
+        "@aws-sdk/credential-provider-ini": "3.651.1",
+        "@aws-sdk/credential-provider-process": "3.649.0",
+        "@aws-sdk/credential-provider-sso": "3.651.1",
+        "@aws-sdk/credential-provider-web-identity": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/credential-provider-imds": "^3.2.1",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.5",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.5",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.651.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.651.1",
+        "@aws-sdk/token-providers": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.5",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.649.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@aws-sdk/util-endpoints": "3.649.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/types": "^3.4.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/token-providers": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.5",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.649.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/types": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/util-endpoints": "^2.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/types": "^3.4.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.649.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/types": "^3.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/core": {
+      "version": "3.635.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^2.4.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/signature-v4": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.620.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.635.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.2.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-stream": "^3.1.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.637.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.620.1",
+        "@aws-sdk/credential-provider-http": "3.635.0",
+        "@aws-sdk/credential-provider-process": "3.620.1",
+        "@aws-sdk/credential-provider-sso": "3.637.0",
+        "@aws-sdk/credential-provider-web-identity": "3.621.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/credential-provider-imds": "^3.2.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.637.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.637.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.620.1",
+        "@aws-sdk/credential-provider-http": "3.635.0",
+        "@aws-sdk/credential-provider-ini": "3.637.0",
+        "@aws-sdk/credential-provider-process": "3.620.1",
+        "@aws-sdk/credential-provider-sso": "3.637.0",
+        "@aws-sdk/credential-provider-web-identity": "3.621.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/credential-provider-imds": "^3.2.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.620.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.637.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.637.0",
+        "@aws-sdk/token-providers": "3.614.0",
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.621.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.621.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.620.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.609.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.620.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.637.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.637.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.614.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/token-providers": {
+      "version": "3.614.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.614.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/types": {
+      "version": "3.609.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.637.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-endpoints": "^2.0.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.568.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.609.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.614.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/abort-controller": {
+      "version": "3.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/config-resolver": {
+      "version": "3.0.8",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/core": {
+      "version": "2.4.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^3.1.3",
+        "@smithy/middleware-retry": "^3.0.18",
+        "@smithy/middleware-serde": "^3.0.6",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/smithy-client": "^3.3.2",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/credential-provider-imds": {
+      "version": "3.2.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/types": "^3.4.2",
+        "@smithy/url-parser": "^3.0.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/eventstream-codec": {
+      "version": "3.1.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/eventstream-serde-browser": {
+      "version": "3.0.9",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^3.0.8",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "3.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/eventstream-serde-node": {
+      "version": "3.0.8",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^3.0.8",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/eventstream-serde-universal": {
+      "version": "3.0.8",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^3.1.5",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/fetch-http-handler": {
+      "version": "3.2.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/querystring-builder": "^3.0.6",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/hash-node": {
+      "version": "3.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/invalid-dependency": {
+      "version": "3.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/middleware-content-length": {
+      "version": "3.0.8",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/middleware-endpoint": {
+      "version": "3.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^3.0.6",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "@smithy/url-parser": "^3.0.6",
+        "@smithy/util-middleware": "^3.0.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/middleware-retry": {
+      "version": "3.0.18",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/service-error-classification": "^3.0.6",
+        "@smithy/smithy-client": "^3.3.2",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-retry": "^3.0.6",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/middleware-serde": {
+      "version": "3.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/middleware-stack": {
+      "version": "3.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/shared-ini-file-loader": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/node-http-handler": {
+      "version": "3.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/querystring-builder": "^3.0.6",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/property-provider": {
+      "version": "3.1.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/protocol-http": {
+      "version": "4.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/querystring-builder": {
+      "version": "3.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/querystring-parser": {
+      "version": "3.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/service-error-classification": {
+      "version": "3.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/signature-v4": {
+      "version": "4.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/smithy-client": {
+      "version": "3.3.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^3.1.3",
+        "@smithy/middleware-stack": "^3.0.6",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-stream": "^3.1.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/types": {
+      "version": "3.4.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/url-parser": {
+      "version": "3.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^3.0.6",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-base64": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-body-length-browser": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-body-length-node": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-config-provider": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "3.0.18",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/smithy-client": "^3.3.2",
+        "@smithy/types": "^3.4.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-defaults-mode-node": {
+      "version": "3.0.18",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^3.0.8",
+        "@smithy/credential-provider-imds": "^3.2.3",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/smithy-client": "^3.3.2",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-endpoints": {
+      "version": "2.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-middleware": {
+      "version": "3.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-retry": {
+      "version": "3.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^3.0.6",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-stream": {
+      "version": "3.1.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^3.2.7",
+        "@smithy/node-http-handler": "^3.2.2",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/bowser": {
+      "version": "2.11.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/charenc": {
       "version": "0.0.2",
@@ -1909,6 +6807,21 @@
         "node": "*"
       }
     },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/ci-info": {
+      "version": "3.9.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/crypt": {
       "version": "0.0.2",
       "dev": true,
@@ -1916,6 +6829,28 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/fs-extra": {
@@ -1932,24 +6867,6 @@
         "node": ">=6 <7 || >=8"
       }
     },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/fs-extra/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/fs-extra/node_modules/universalify": {
-      "version": "0.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/graceful-fs": {
       "version": "4.2.11",
       "dev": true,
@@ -1957,7 +6874,7 @@
       "license": "ISC"
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/graphql": {
-      "version": "15.8.0",
+      "version": "15.9.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -1966,19 +6883,19 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/graphql-mapping-template": {
-      "version": "5.0.0",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/graphql-transformer-common": {
-      "version": "5.0.0",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "graphql": "^15.5.0",
-        "graphql-mapping-template": "5.0.0",
+        "graphql-mapping-template": "5.0.1",
         "md5": "^2.2.1",
         "pluralize": "8.0.0"
       }
@@ -2003,36 +6920,28 @@
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/is-buffer": {
-      "version": "2.0.5",
+      "version": "1.1.6",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
       "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
+      "license": "MIT"
     },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/jsonfile": {
-      "version": "6.1.0",
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/is-ci": {
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "universalify": "^2.0.0"
+        "ci-info": "^3.2.0"
       },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -2049,6 +6958,12 @@
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/md5": {
       "version": "2.3.0",
       "dev": true,
@@ -2059,12 +6974,6 @@
         "crypt": "0.0.2",
         "is-buffer": "~1.1.6"
       }
-    },
-    "node_modules/@aws-amplify/graphql-api-construct/node_modules/md5/node_modules/is-buffer": {
-      "version": "1.1.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/object-hash": {
       "version": "3.0.0",
@@ -2084,6 +6993,24 @@
         "node": ">=4"
       }
     },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/semver": {
+      "version": "7.6.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/strnum": {
+      "version": "1.0.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/ts-dedent": {
       "version": "2.2.0",
       "dev": true,
@@ -2093,17 +7020,36 @@
         "node": ">=6.10"
       }
     },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/tslib": {
+      "version": "2.7.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD"
+    },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/universalify": {
-      "version": "2.0.0",
+      "version": "0.1.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-api-construct/node_modules/uuid": {
+      "version": "9.0.1",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-amplify/graphql-api-construct/node_modules/zod": {
-      "version": "3.22.4",
+      "version": "3.23.8",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -2259,12 +7205,12 @@
       }
     },
     "node_modules/@aws-amplify/graphql-generator": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-generator/-/graphql-generator-0.4.4.tgz",
-      "integrity": "sha512-rezm/C7pxoguakn6CclTDxmUgBjMKAZejc0X6LrSNT0gxg4Xs6GafZAWCx0m8dgb3gK5imIyCtU6H1AF2KXSew==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-generator/-/graphql-generator-0.4.7.tgz",
+      "integrity": "sha512-/qvbd2A9E0adBQxNgQ9QMxyRjexborSDT5evz1Ytr/imOd2MGNNEQEhzlHSc5Lt3L4m+H3l8dFb/V7IHbx5vzw==",
       "dev": true,
       "dependencies": {
-        "@aws-amplify/appsync-modelgen-plugin": "2.12.3",
+        "@aws-amplify/appsync-modelgen-plugin": "2.13.2",
         "@aws-amplify/graphql-directives": "^1.0.1",
         "@aws-amplify/graphql-docs-generator": "4.2.1",
         "@aws-amplify/graphql-types-generator": "3.6.0",
@@ -2637,6 +7583,21 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-amplify/graphql-schema-generator/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz",
+      "integrity": "sha512-ExuILJ2qLW5ZO+rgkNRj0xiAipKT16Rk77buvPP8csR7kkCflT/gXTyzRe/uzIiETTxM7tr8xuO9MP/DQXqkfg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws-amplify/graphql-schema-generator/node_modules/@aws-sdk/credential-provider-http": {
       "version": "3.622.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.622.0.tgz",
@@ -2705,6 +7666,22 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-amplify/graphql-schema-generator/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.620.1.tgz",
+      "integrity": "sha512-hWqFMidqLAkaV9G460+1at6qa9vySbjQKKc04p59OT7lZ5cO5VH5S4aI05e+m4j364MBROjjk2ugNvfNf/8ILg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws-amplify/graphql-schema-generator/node_modules/@aws-sdk/credential-provider-sso": {
       "version": "3.624.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.624.0.tgz",
@@ -2716,6 +7693,68 @@
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
         "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-schema-generator/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.621.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.621.0.tgz",
+      "integrity": "sha512-w7ASSyfNvcx7+bYGep3VBgC3K6vEdLmlpjT7nSIHxxQf+WSdvy+HynwJosrpZax0sK5q0D1Jpn/5q+r5lwwW6w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.621.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-schema-generator/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
+      "integrity": "sha512-VMtPEZwqYrII/oUkffYsNWY9PZ9xpNJpMgmyU0rlDQ25O1c0Hk3fJmZRe6pEkAJ0omD7kLrqGl1DUjQVxpd/Rg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-schema-generator/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
+      "integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-schema-generator/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz",
+      "integrity": "sha512-nh91S7aGK3e/o1ck64sA/CyoFw+gAYj2BDOnoNa6ouyCrVJED96ZXWbhye/fz9SgmNUZR2g7GdVpiLpMKZoI5w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -2739,6 +7778,55 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-amplify/graphql-schema-generator/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
+      "integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-schema-generator/node_modules/@aws-sdk/token-providers": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
+      "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.614.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-schema-generator/node_modules/@aws-sdk/types": {
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
+      "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws-amplify/graphql-schema-generator/node_modules/@aws-sdk/util-endpoints": {
       "version": "3.614.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.614.0.tgz",
@@ -2754,15 +7842,50 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-amplify/graphql-schema-generator/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
-      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+    "node_modules/@aws-amplify/graphql-schema-generator/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
+      "integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
       "dev": true,
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@aws-sdk/types": "3.609.0",
         "@smithy/types": "^3.3.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-schema-generator/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
+      "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-amplify/graphql-schema-generator/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2770,12 +7893,25 @@
       }
     },
     "node_modules/@aws-amplify/graphql-schema-generator/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-amplify/graphql-schema-generator/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3041,16 +8177,17 @@
       }
     },
     "node_modules/@aws-amplify/model-generator": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/model-generator/-/model-generator-1.0.5.tgz",
-      "integrity": "sha512-1iwjDeNxBOEZSzcLtGGNiMBGmBNe6IZN9As/fMTbkZejWsw9zYlp0SwS/AdTN5ka4ZwiMRP+mON/jGod7ODpjg==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/model-generator/-/model-generator-1.0.8.tgz",
+      "integrity": "sha512-raf8S+d6qRhQDCahsV6QxEOTLWrdahscNdCCuC0NECqxueFZEy6Ju9LUiYUQrqXQafjfpNm88+fTWRFCcHJw4w==",
       "dev": true,
       "dependencies": {
         "@aws-amplify/backend-output-schemas": "^1.1.0",
-        "@aws-amplify/deployed-backend-client": "^1.3.0",
+        "@aws-amplify/deployed-backend-client": "^1.4.1",
         "@aws-amplify/graphql-generator": "^0.4.0",
         "@aws-amplify/graphql-types-generator": "^3.6.0",
         "@aws-amplify/platform-core": "^1.0.5",
+        "@aws-amplify/plugin-types": "^1.3.0",
         "@aws-sdk/client-appsync": "^3.624.0",
         "@aws-sdk/client-s3": "^3.624.0",
         "@aws-sdk/credential-providers": "^3.624.0",
@@ -3063,9 +8200,9 @@
       }
     },
     "node_modules/@aws-amplify/notifications": {
-      "version": "2.0.44",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/notifications/-/notifications-2.0.44.tgz",
-      "integrity": "sha512-tFoJTKJAmwy+Jn2MNzn/3Rq5CqebWqVUEIHaPNLN/Cqx035EOlFEp78fxe1V/S+LaFjCipWA2JuAHsh2DsZnbw==",
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/notifications/-/notifications-2.0.53.tgz",
+      "integrity": "sha512-jSRmj2uEnW9jkG17WoJ3Zjry3om40fNN/tAZAs3ydxjuj8tjqYl/MpdYq9NhSA8HHFOeu7YhKrIcyyZp9RKlYw==",
       "dependencies": {
         "lodash": "^4.17.21",
         "tslib": "^2.5.0"
@@ -3075,23 +8212,24 @@
       }
     },
     "node_modules/@aws-amplify/platform-core": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/platform-core/-/platform-core-1.0.6.tgz",
-      "integrity": "sha512-6wgold2ZvKKQeor7i9617CmGJVoa00rWmLNsWBBipzzjflyt/h8r2mdAQVN7rNS5uzSDsm+VMxO7IAvS8auQBQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/platform-core/-/platform-core-1.1.0.tgz",
+      "integrity": "sha512-9iOM+dpht1f52WUHPyaXyeF8Z27TNgqBS86JmIhcsqWltUsCqoQDKPVjaTj8No05oMzm+icWc96dPG/EZIE3jw==",
       "dev": true,
       "dependencies": {
         "@aws-amplify/plugin-types": "^1.2.1",
         "@aws-sdk/client-sts": "^3.624.0",
         "is-ci": "^3.0.1",
         "lodash.mergewith": "^4.6.2",
+        "semver": "^7.6.3",
         "uuid": "^9.0.1",
         "zod": "^3.22.2"
       }
     },
     "node_modules/@aws-amplify/plugin-types": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/plugin-types/-/plugin-types-1.2.1.tgz",
-      "integrity": "sha512-rqsc9F05hO58oVCcdvbkE3zUaS4iKdhm4C3eReWd6NNLfBmfQuoy46CeyHw2GrbKtdxmCckAOU0k6L71sa8nNA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/plugin-types/-/plugin-types-1.3.0.tgz",
+      "integrity": "sha512-MEDczuMiTm8Rer3LQQl3AgEpH3Ws/JH/1FkPTdHAwBie6toeyl624t6E9wuLQ3AikId/R7Pbi6DHr4YmCSus0g==",
       "dev": true,
       "peerDependencies": {
         "@aws-sdk/types": "^3.609.0",
@@ -3100,24 +8238,23 @@
       }
     },
     "node_modules/@aws-amplify/sandbox": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/sandbox/-/sandbox-1.2.0.tgz",
-      "integrity": "sha512-+lNMo2S1xv5jHQdeNVab90ozqOIN3lJ4P4+jusPC8J27L8n2GnpcKaugi0as8YJOt94V984hQuAZzLvtDmgHsQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/sandbox/-/sandbox-1.2.3.tgz",
+      "integrity": "sha512-MJIeW1X6xShuazp7RepHcsuP/Dy/hMdmObwRCdsjrZRNZOAN8e63dYSdkxtqVHr0Mk2fZ9WrIrCiu8PYbx7b9A==",
       "dev": true,
       "dependencies": {
-        "@aws-amplify/backend-deployer": "^1.1.0",
-        "@aws-amplify/backend-secret": "^1.1.0",
-        "@aws-amplify/cli-core": "^1.1.2",
-        "@aws-amplify/client-config": "^1.1.3",
-        "@aws-amplify/deployed-backend-client": "^1.3.0",
+        "@aws-amplify/backend-deployer": "^1.1.3",
+        "@aws-amplify/backend-secret": "^1.1.2",
+        "@aws-amplify/cli-core": "^1.1.3",
+        "@aws-amplify/client-config": "^1.3.1",
+        "@aws-amplify/deployed-backend-client": "^1.4.1",
         "@aws-amplify/platform-core": "^1.0.6",
-        "@aws-sdk/client-cloudformation": "^3.624.0",
+        "@aws-amplify/plugin-types": "^1.2.2",
         "@aws-sdk/client-cloudwatch-logs": "^3.624.0",
         "@aws-sdk/client-lambda": "^3.624.0",
         "@aws-sdk/client-ssm": "^3.624.0",
         "@aws-sdk/credential-providers": "^3.624.0",
         "@aws-sdk/types": "^3.609.0",
-        "@aws-sdk/util-arn-parser": "^3.568.0",
         "@parcel/watcher": "^2.4.1",
         "debounce-promise": "^3.1.2",
         "glob": "^10.2.7",
@@ -3129,9 +8266,9 @@
       }
     },
     "node_modules/@aws-amplify/schema-generator": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/schema-generator/-/schema-generator-1.2.1.tgz",
-      "integrity": "sha512-6UhwwuGE++BKClHi3ogjm3Fzx+VyFeGhZhcy/RDvmxSehui1nDJV1FjePR42Y+q+YWEb/FPWEivuk/VrQuVcNQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/schema-generator/-/schema-generator-1.2.4.tgz",
+      "integrity": "sha512-tSDsC1Se6dIj56ej53HQ+CDvqAMnqXbDnLzmlUhWu0tjp0j+EQ1YJMYJyUUZywLNtDGiKyKWdHt98eDvogb8lQ==",
       "dev": true,
       "dependencies": {
         "@aws-amplify/graphql-schema-generator": "^0.9.4",
@@ -3139,9 +8276,9 @@
       }
     },
     "node_modules/@aws-amplify/storage": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-6.6.2.tgz",
-      "integrity": "sha512-8GS7/mltRLVIbiq3sRasHtRtkKCxC5vDROt3J/ZrMmICGJhr07frh3IzGi3Q6/PxrIe2Kkg9XBqYsZULhhW7Og==",
+      "version": "6.6.11",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-6.6.11.tgz",
+      "integrity": "sha512-Q+sA76Af5HH9SCey57AOvc2QilyNcrIE+NVR4xPk8WN/RQKZwkCH9naryZufXclAuUYSEjD6peUptaaHICQsKg==",
       "dependencies": {
         "@aws-sdk/types": "3.398.0",
         "@smithy/md5-js": "2.0.7",
@@ -3160,17 +8297,6 @@
       "dependencies": {
         "@smithy/types": "^2.2.2",
         "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/storage/node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -3197,41 +8323,18 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-amplify/storage/node_modules/@smithy/util-buffer-from": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-amplify/storage/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-amplify/ui": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/ui/-/ui-6.1.0.tgz",
-      "integrity": "sha512-bZhjRQDLo0CT9uwLspp14IktKKTcGYQh3730NT7kcWcuWM/A8PJAPVhGD7AQ1aLSZ4ytzvxLhxT3UBU1JNVAIg==",
+      "version": "6.6.5",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/ui/-/ui-6.6.5.tgz",
+      "integrity": "sha512-J74i0amcVeFWtPDvkQ1pKF78ea5b6Usi4DUiKHusstCQ0SmHbuxU5JLdW9Zz5luZFgRnm1SL/f7sJz6XGG1TTA==",
       "dependencies": {
         "csstype": "^3.1.1",
         "lodash": "4.17.21",
         "tslib": "^2.5.2"
       },
       "peerDependencies": {
-        "aws-amplify": "^6.3.2",
+        "@aws-amplify/core": "*",
+        "aws-amplify": "^6.6.5",
         "xstate": "^4.33.6"
       },
       "peerDependenciesMeta": {
@@ -3241,12 +8344,12 @@
       }
     },
     "node_modules/@aws-amplify/ui-react": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react/-/ui-react-6.2.0.tgz",
-      "integrity": "sha512-/NJ5Uh11EUYePTzqItwbqp+Jq5bJfwwwzKm0ceixf6+4M8t9kHlxnLJaDgKMGi8nme9oPkp8aPzlT8kiyqMCjw==",
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react/-/ui-react-6.5.5.tgz",
+      "integrity": "sha512-2aqIig071MUNrw0wxNlF/7nZmhT7p7dOfy4/zjF/QkfvX/hAippu/pGkLuFABoWofoBkcsFad6I4Cr1vCTbAVg==",
       "dependencies": {
-        "@aws-amplify/ui": "6.1.0",
-        "@aws-amplify/ui-react-core": "3.0.18",
+        "@aws-amplify/ui": "6.6.5",
+        "@aws-amplify/ui-react-core": "3.0.29",
         "@radix-ui/react-direction": "1.0.0",
         "@radix-ui/react-dropdown-menu": "1.0.0",
         "@radix-ui/react-slider": "1.0.0",
@@ -3256,7 +8359,8 @@
         "tslib": "^2.5.2"
       },
       "peerDependencies": {
-        "aws-amplify": "^6.3.2",
+        "@aws-amplify/core": "*",
+        "aws-amplify": "^6.6.5",
         "react": "^16.14.0 || ^17.0 || ^18.0",
         "react-dom": "^16.14.0 || ^17.0 || ^18.0"
       },
@@ -3267,43 +8371,43 @@
       }
     },
     "node_modules/@aws-amplify/ui-react-core": {
-      "version": "3.0.18",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react-core/-/ui-react-core-3.0.18.tgz",
-      "integrity": "sha512-Jv657+4DYhK5zWOobcj4nobel+9fhy6VeDg61/fVOK2FybH7HnqjacRnOd49GC1bKBM5ui8sj4RVCO2wi7638Q==",
+      "version": "3.0.29",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/ui-react-core/-/ui-react-core-3.0.29.tgz",
+      "integrity": "sha512-myOu26P0GTjPkxJHiXRhIXo+gs42GFtxVTRTSRynKnljadVb3wnWDJdFZH1pAFtwux79uwQtptpkN7O0/nTLXw==",
       "dependencies": {
-        "@aws-amplify/ui": "6.1.0",
+        "@aws-amplify/ui": "6.6.5",
         "@xstate/react": "^3.2.2",
         "lodash": "4.17.21",
         "react-hook-form": "^7.43.5",
         "xstate": "^4.33.6"
       },
       "peerDependencies": {
-        "aws-amplify": "^6.3.2",
+        "aws-amplify": "^6.6.5",
         "react": "^16.14.0 || ^17.0 || ^18.0"
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.202",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.202.tgz",
-      "integrity": "sha512-JqlF0D4+EVugnG5dAsNZMqhu3HW7ehOXm5SDMxMbXNDMdsF0pxtQKNHRl52z1U9igsHmaFpUgSGjbhAJ+0JONg==",
+      "version": "2.2.208",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.208.tgz",
+      "integrity": "sha512-r4CuHZaiBioU6waWhCNdEL4MO1+rfbcYVS/Ndz1XNGB5cxIRZwAS0Si6qD2D6nsgpPojiruFl67T1t5M9Va8kQ==",
       "dev": true
     },
     "node_modules/@aws-cdk/asset-kubectl-v20": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
-      "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.3.tgz",
+      "integrity": "sha512-cDG1w3ieM6eOT9mTefRuTypk95+oyD7P5X/wRltwmYxU7nZc3+076YEVS6vrjDKr3ADYbfn0lDKpfB1FBtO9CQ==",
       "dev": true
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.3.tgz",
-      "integrity": "sha512-twhuEG+JPOYCYPx/xy5uH2+VUsIEhPTzDY0F1KuB+ocjWWB/KEDiOVL19nHvbPCB6fhWnkykXEMJ4HHcKvjtvg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz",
+      "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==",
       "dev": true
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "36.0.14",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-36.0.14.tgz",
-      "integrity": "sha512-8ecWc6vjOXzQjFuzLOX4L28u8ZQn13vNOd6N2cYu26+LuZHoxZAIyyITldLNazxbiqJ1aNSsa++GlvO/wEpGjQ==",
+      "version": "38.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-38.0.1.tgz",
+      "integrity": "sha512-KvPe+NMWAulfNVwY7jenFhzhuLhLqJ/OPy5jx7wUstbjnYnjRVLpUHPU3yCjXFE0J8cuJVdx95BJ4rOs66Pi9w==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -3312,9 +8416,6 @@
       "dependencies": {
         "jsonschema": "^1.4.1",
         "semver": "^7.6.3"
-      },
-      "engines": {
-        "node": ">= 18.18.0"
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
@@ -3376,44 +8477,6 @@
         "tslib": "^2.6.2"
       }
     },
-    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
@@ -3426,41 +8489,6 @@
         "@aws-sdk/util-locate-window": "^3.0.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-crypto/sha256-js": {
@@ -3494,87 +8522,82 @@
         "tslib": "^2.6.2"
       }
     },
-    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-amplify": {
-      "version": "3.637.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-amplify/-/client-amplify-3.637.0.tgz",
-      "integrity": "sha512-WFR9mncU9aK4OfYW66uQnBOzzQElLXie01dLAhq6FrDVqjCa7m2ERii57pCaAQet2LtVlDvn0nEGxjzkaPDtVQ==",
+      "version": "3.677.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-amplify/-/client-amplify-3.677.0.tgz",
+      "integrity": "sha512-nZJ/t5cAoqf52so71qbwNQdLyFdvzCXnd1HxJ9SgiM3ho1I32gIBA93lybOfROEp5cPd6K2/8eiSSSdK16pVBQ==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.637.0",
-        "@aws-sdk/client-sts": "3.637.0",
-        "@aws-sdk/core": "3.635.0",
-        "@aws-sdk/credential-provider-node": "3.637.0",
-        "@aws-sdk/middleware-host-header": "3.620.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.620.0",
-        "@aws-sdk/middleware-user-agent": "3.637.0",
-        "@aws-sdk/region-config-resolver": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.637.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.614.0",
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.4.0",
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.5",
-        "@smithy/middleware-endpoint": "^3.1.0",
-        "@smithy/middleware-retry": "^3.0.15",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/smithy-client": "^3.2.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
+        "@aws-sdk/client-sso-oidc": "3.677.0",
+        "@aws-sdk/client-sts": "3.677.0",
+        "@aws-sdk/core": "3.677.0",
+        "@aws-sdk/credential-provider-node": "3.677.0",
+        "@aws-sdk/middleware-host-header": "3.667.0",
+        "@aws-sdk/middleware-logger": "3.667.0",
+        "@aws-sdk/middleware-recursion-detection": "3.667.0",
+        "@aws-sdk/middleware-user-agent": "3.677.0",
+        "@aws-sdk/region-config-resolver": "3.667.0",
+        "@aws-sdk/types": "3.667.0",
+        "@aws-sdk/util-endpoints": "3.667.0",
+        "@aws-sdk/util-user-agent-browser": "3.675.0",
+        "@aws-sdk/util-user-agent-node": "3.677.0",
+        "@smithy/config-resolver": "^3.0.9",
+        "@smithy/core": "^2.4.8",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/hash-node": "^3.0.7",
+        "@smithy/invalid-dependency": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.9",
+        "@smithy/middleware-endpoint": "^3.1.4",
+        "@smithy/middleware-retry": "^3.0.23",
+        "@smithy/middleware-serde": "^3.0.7",
+        "@smithy/middleware-stack": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/url-parser": "^3.0.7",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.15",
-        "@smithy/util-defaults-mode-node": "^3.0.15",
-        "@smithy/util-endpoints": "^2.0.5",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-defaults-mode-browser": "^3.0.23",
+        "@smithy/util-defaults-mode-node": "^3.0.23",
+        "@smithy/util-endpoints": "^2.1.3",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-retry": "^3.0.7",
         "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-amplify/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.667.0.tgz",
+      "integrity": "sha512-iNr+JhhA902JMKHG9IwT9YdaEx6KGl6vjAL5BRNeOjfj4cZYMog6Lz/IlfOAltMtT0w88DAHDEFrBd2uO0l2eg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.667.0",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-amplify/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3582,14 +8605,14 @@
       }
     },
     "node_modules/@aws-sdk/client-amplify/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
-      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
       "dev": true,
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3597,12 +8620,25 @@
       }
     },
     "node_modules/@aws-sdk/client-amplify/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-amplify/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3610,51 +8646,52 @@
       }
     },
     "node_modules/@aws-sdk/client-amplifyuibuilder": {
-      "version": "3.637.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-amplifyuibuilder/-/client-amplifyuibuilder-3.637.0.tgz",
-      "integrity": "sha512-A3L/XfXupyTLakx4qzjQXhAI7J+K8K0k/Tm5xlFgpe4d95C1OsUYv0B+w5kNwpegVIvl4LhLRVWpq/EF9bha+w==",
+      "version": "3.677.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-amplifyuibuilder/-/client-amplifyuibuilder-3.677.0.tgz",
+      "integrity": "sha512-rCugpKm22gWxWAfnxUep3J6+fR58a3HgI5eAppHh+yKgkfRkxBBlmmngvi7+6+5NPpdHBGb6sy/vctXley8i9A==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.637.0",
-        "@aws-sdk/client-sts": "3.637.0",
-        "@aws-sdk/core": "3.635.0",
-        "@aws-sdk/credential-provider-node": "3.637.0",
-        "@aws-sdk/middleware-host-header": "3.620.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.620.0",
-        "@aws-sdk/middleware-user-agent": "3.637.0",
-        "@aws-sdk/region-config-resolver": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.637.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.614.0",
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.4.0",
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.5",
-        "@smithy/middleware-endpoint": "^3.1.0",
-        "@smithy/middleware-retry": "^3.0.15",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/smithy-client": "^3.2.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
+        "@aws-sdk/client-sso-oidc": "3.677.0",
+        "@aws-sdk/client-sts": "3.677.0",
+        "@aws-sdk/core": "3.677.0",
+        "@aws-sdk/credential-provider-node": "3.677.0",
+        "@aws-sdk/middleware-host-header": "3.667.0",
+        "@aws-sdk/middleware-logger": "3.667.0",
+        "@aws-sdk/middleware-recursion-detection": "3.667.0",
+        "@aws-sdk/middleware-user-agent": "3.677.0",
+        "@aws-sdk/region-config-resolver": "3.667.0",
+        "@aws-sdk/types": "3.667.0",
+        "@aws-sdk/util-endpoints": "3.667.0",
+        "@aws-sdk/util-user-agent-browser": "3.675.0",
+        "@aws-sdk/util-user-agent-node": "3.677.0",
+        "@smithy/config-resolver": "^3.0.9",
+        "@smithy/core": "^2.4.8",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/hash-node": "^3.0.7",
+        "@smithy/invalid-dependency": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.9",
+        "@smithy/middleware-endpoint": "^3.1.4",
+        "@smithy/middleware-retry": "^3.0.23",
+        "@smithy/middleware-serde": "^3.0.7",
+        "@smithy/middleware-stack": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/url-parser": "^3.0.7",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.15",
-        "@smithy/util-defaults-mode-node": "^3.0.15",
-        "@smithy/util-endpoints": "^2.0.5",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-defaults-mode-browser": "^3.0.23",
+        "@smithy/util-defaults-mode-node": "^3.0.23",
+        "@smithy/util-endpoints": "^2.1.3",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-retry": "^3.0.7",
         "@smithy/util-utf8": "^3.0.0",
+        "@types/uuid": "^9.0.1",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
       },
@@ -3662,15 +8699,45 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-amplifyuibuilder/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
-      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+    "node_modules/@aws-sdk/client-amplifyuibuilder/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.667.0.tgz",
+      "integrity": "sha512-iNr+JhhA902JMKHG9IwT9YdaEx6KGl6vjAL5BRNeOjfj4cZYMog6Lz/IlfOAltMtT0w88DAHDEFrBd2uO0l2eg==",
       "dev": true,
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/types": "3.667.0",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-amplifyuibuilder/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-amplifyuibuilder/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3678,12 +8745,25 @@
       }
     },
     "node_modules/@aws-sdk/client-amplifyuibuilder/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-amplifyuibuilder/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3691,52 +8771,82 @@
       }
     },
     "node_modules/@aws-sdk/client-appsync": {
-      "version": "3.637.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-appsync/-/client-appsync-3.637.0.tgz",
-      "integrity": "sha512-ylG/+WWYglz4okozvR2xy/4bJw/o9No+Xp4N8v4MLkGqDlFeMgrlxLLP9NvXZaHjPYjPZ2o4yR1om66imFxs2A==",
+      "version": "3.677.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-appsync/-/client-appsync-3.677.0.tgz",
+      "integrity": "sha512-lfS7whXi7ZMr3XRRugaFF4zoajXoYkUmlY4p1FcMHxtP52EF9cOBtrttJsOp5Gy5aheNPMK0SAsxG0AfUZlaYw==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.637.0",
-        "@aws-sdk/client-sts": "3.637.0",
-        "@aws-sdk/core": "3.635.0",
-        "@aws-sdk/credential-provider-node": "3.637.0",
-        "@aws-sdk/middleware-host-header": "3.620.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.620.0",
-        "@aws-sdk/middleware-user-agent": "3.637.0",
-        "@aws-sdk/region-config-resolver": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.637.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.614.0",
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.4.0",
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.5",
-        "@smithy/middleware-endpoint": "^3.1.0",
-        "@smithy/middleware-retry": "^3.0.15",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/smithy-client": "^3.2.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
+        "@aws-sdk/client-sso-oidc": "3.677.0",
+        "@aws-sdk/client-sts": "3.677.0",
+        "@aws-sdk/core": "3.677.0",
+        "@aws-sdk/credential-provider-node": "3.677.0",
+        "@aws-sdk/middleware-host-header": "3.667.0",
+        "@aws-sdk/middleware-logger": "3.667.0",
+        "@aws-sdk/middleware-recursion-detection": "3.667.0",
+        "@aws-sdk/middleware-user-agent": "3.677.0",
+        "@aws-sdk/region-config-resolver": "3.667.0",
+        "@aws-sdk/types": "3.667.0",
+        "@aws-sdk/util-endpoints": "3.667.0",
+        "@aws-sdk/util-user-agent-browser": "3.675.0",
+        "@aws-sdk/util-user-agent-node": "3.677.0",
+        "@smithy/config-resolver": "^3.0.9",
+        "@smithy/core": "^2.4.8",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/hash-node": "^3.0.7",
+        "@smithy/invalid-dependency": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.9",
+        "@smithy/middleware-endpoint": "^3.1.4",
+        "@smithy/middleware-retry": "^3.0.23",
+        "@smithy/middleware-serde": "^3.0.7",
+        "@smithy/middleware-stack": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/url-parser": "^3.0.7",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.15",
-        "@smithy/util-defaults-mode-node": "^3.0.15",
-        "@smithy/util-endpoints": "^2.0.5",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
-        "@smithy/util-stream": "^3.1.3",
+        "@smithy/util-defaults-mode-browser": "^3.0.23",
+        "@smithy/util-defaults-mode-node": "^3.0.23",
+        "@smithy/util-endpoints": "^2.1.3",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-retry": "^3.0.7",
+        "@smithy/util-stream": "^3.1.9",
         "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-appsync/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.667.0.tgz",
+      "integrity": "sha512-iNr+JhhA902JMKHG9IwT9YdaEx6KGl6vjAL5BRNeOjfj4cZYMog6Lz/IlfOAltMtT0w88DAHDEFrBd2uO0l2eg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.667.0",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-appsync/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3744,14 +8854,14 @@
       }
     },
     "node_modules/@aws-sdk/client-appsync/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
-      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
       "dev": true,
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3759,12 +8869,25 @@
       }
     },
     "node_modules/@aws-sdk/client-appsync/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-appsync/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3772,52 +8895,53 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudformation": {
-      "version": "3.637.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.637.0.tgz",
-      "integrity": "sha512-fjXVo7nDnp13yNq2xZywOuCC2x4Y4PLGN9fHyC4QTgoqmdieNoPVsFyVKUVhi79T0Emz+vd6AqmeuBbYeX/w6A==",
+      "version": "3.677.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.677.0.tgz",
+      "integrity": "sha512-EqBqvt6XG+BTNqe/r+34c34brqdxdIaUYLKoZ2RaOfTfQrqiy/kEtTxlImq7cT+UXvHv7WmCHGTpqDwqdLbjZA==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.637.0",
-        "@aws-sdk/client-sts": "3.637.0",
-        "@aws-sdk/core": "3.635.0",
-        "@aws-sdk/credential-provider-node": "3.637.0",
-        "@aws-sdk/middleware-host-header": "3.620.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.620.0",
-        "@aws-sdk/middleware-user-agent": "3.637.0",
-        "@aws-sdk/region-config-resolver": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.637.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.614.0",
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.4.0",
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.5",
-        "@smithy/middleware-endpoint": "^3.1.0",
-        "@smithy/middleware-retry": "^3.0.15",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/smithy-client": "^3.2.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
+        "@aws-sdk/client-sso-oidc": "3.677.0",
+        "@aws-sdk/client-sts": "3.677.0",
+        "@aws-sdk/core": "3.677.0",
+        "@aws-sdk/credential-provider-node": "3.677.0",
+        "@aws-sdk/middleware-host-header": "3.667.0",
+        "@aws-sdk/middleware-logger": "3.667.0",
+        "@aws-sdk/middleware-recursion-detection": "3.667.0",
+        "@aws-sdk/middleware-user-agent": "3.677.0",
+        "@aws-sdk/region-config-resolver": "3.667.0",
+        "@aws-sdk/types": "3.667.0",
+        "@aws-sdk/util-endpoints": "3.667.0",
+        "@aws-sdk/util-user-agent-browser": "3.675.0",
+        "@aws-sdk/util-user-agent-node": "3.677.0",
+        "@smithy/config-resolver": "^3.0.9",
+        "@smithy/core": "^2.4.8",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/hash-node": "^3.0.7",
+        "@smithy/invalid-dependency": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.9",
+        "@smithy/middleware-endpoint": "^3.1.4",
+        "@smithy/middleware-retry": "^3.0.23",
+        "@smithy/middleware-serde": "^3.0.7",
+        "@smithy/middleware-stack": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/url-parser": "^3.0.7",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.15",
-        "@smithy/util-defaults-mode-node": "^3.0.15",
-        "@smithy/util-endpoints": "^2.0.5",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-defaults-mode-browser": "^3.0.23",
+        "@smithy/util-defaults-mode-node": "^3.0.23",
+        "@smithy/util-endpoints": "^2.1.3",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-retry": "^3.0.7",
         "@smithy/util-utf8": "^3.0.0",
-        "@smithy/util-waiter": "^3.1.2",
+        "@smithy/util-waiter": "^3.1.6",
+        "@types/uuid": "^9.0.1",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
       },
@@ -3825,15 +8949,45 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
-      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.667.0.tgz",
+      "integrity": "sha512-iNr+JhhA902JMKHG9IwT9YdaEx6KGl6vjAL5BRNeOjfj4cZYMog6Lz/IlfOAltMtT0w88DAHDEFrBd2uO0l2eg==",
       "dev": true,
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/types": "3.667.0",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3841,12 +8995,25 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3854,54 +9021,55 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudwatch-logs": {
-      "version": "3.637.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.637.0.tgz",
-      "integrity": "sha512-JK9BgR3zHo/3VHSMO5ovDgk95TGEiY1DnlJ1AIPl/t6i87gZojurQFlbVuwzLDMZGoFfH0FuAJTW2+sH6nzh8A==",
+      "version": "3.677.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.677.0.tgz",
+      "integrity": "sha512-I7FFZpb4gCiyTAn4U2sVOEeRajQ11EKSrxuO6srd4k+g3L30Rs8s6P7droJQKruaAn4m/ujkpyNNajOPXtSCjw==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.637.0",
-        "@aws-sdk/client-sts": "3.637.0",
-        "@aws-sdk/core": "3.635.0",
-        "@aws-sdk/credential-provider-node": "3.637.0",
-        "@aws-sdk/middleware-host-header": "3.620.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.620.0",
-        "@aws-sdk/middleware-user-agent": "3.637.0",
-        "@aws-sdk/region-config-resolver": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.637.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.614.0",
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.4.0",
-        "@smithy/eventstream-serde-browser": "^3.0.6",
-        "@smithy/eventstream-serde-config-resolver": "^3.0.3",
-        "@smithy/eventstream-serde-node": "^3.0.5",
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.5",
-        "@smithy/middleware-endpoint": "^3.1.0",
-        "@smithy/middleware-retry": "^3.0.15",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/smithy-client": "^3.2.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
+        "@aws-sdk/client-sso-oidc": "3.677.0",
+        "@aws-sdk/client-sts": "3.677.0",
+        "@aws-sdk/core": "3.677.0",
+        "@aws-sdk/credential-provider-node": "3.677.0",
+        "@aws-sdk/middleware-host-header": "3.667.0",
+        "@aws-sdk/middleware-logger": "3.667.0",
+        "@aws-sdk/middleware-recursion-detection": "3.667.0",
+        "@aws-sdk/middleware-user-agent": "3.677.0",
+        "@aws-sdk/region-config-resolver": "3.667.0",
+        "@aws-sdk/types": "3.667.0",
+        "@aws-sdk/util-endpoints": "3.667.0",
+        "@aws-sdk/util-user-agent-browser": "3.675.0",
+        "@aws-sdk/util-user-agent-node": "3.677.0",
+        "@smithy/config-resolver": "^3.0.9",
+        "@smithy/core": "^2.4.8",
+        "@smithy/eventstream-serde-browser": "^3.0.10",
+        "@smithy/eventstream-serde-config-resolver": "^3.0.7",
+        "@smithy/eventstream-serde-node": "^3.0.9",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/hash-node": "^3.0.7",
+        "@smithy/invalid-dependency": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.9",
+        "@smithy/middleware-endpoint": "^3.1.4",
+        "@smithy/middleware-retry": "^3.0.23",
+        "@smithy/middleware-serde": "^3.0.7",
+        "@smithy/middleware-stack": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/url-parser": "^3.0.7",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.15",
-        "@smithy/util-defaults-mode-node": "^3.0.15",
-        "@smithy/util-endpoints": "^2.0.5",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-defaults-mode-browser": "^3.0.23",
+        "@smithy/util-defaults-mode-node": "^3.0.23",
+        "@smithy/util-endpoints": "^2.1.3",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-retry": "^3.0.7",
         "@smithy/util-utf8": "^3.0.0",
+        "@types/uuid": "^9.0.1",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
       },
@@ -3909,15 +9077,45 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
-      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.667.0.tgz",
+      "integrity": "sha512-iNr+JhhA902JMKHG9IwT9YdaEx6KGl6vjAL5BRNeOjfj4cZYMog6Lz/IlfOAltMtT0w88DAHDEFrBd2uO0l2eg==",
       "dev": true,
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/types": "3.667.0",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3925,12 +9123,25 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3938,50 +9149,50 @@
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity": {
-      "version": "3.637.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.637.0.tgz",
-      "integrity": "sha512-391mca6yEfXVcSOTLGcxzlT0QCFfvoymLlVHfb//bzl806UUTq12cR2k+AnaCKLj+QSejmA7n6lwZWADm00Fvg==",
+      "version": "3.677.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.677.0.tgz",
+      "integrity": "sha512-wGhbHAZGa5VeVLCyAfhyFWXl+JfsHSgSl0eodH6xqKoR60LTDJZbBgQZizUwSj8EoSzsglBvgPLYZaLfXTKM/g==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.637.0",
-        "@aws-sdk/client-sts": "3.637.0",
-        "@aws-sdk/core": "3.635.0",
-        "@aws-sdk/credential-provider-node": "3.637.0",
-        "@aws-sdk/middleware-host-header": "3.620.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.620.0",
-        "@aws-sdk/middleware-user-agent": "3.637.0",
-        "@aws-sdk/region-config-resolver": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.637.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.614.0",
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.4.0",
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.5",
-        "@smithy/middleware-endpoint": "^3.1.0",
-        "@smithy/middleware-retry": "^3.0.15",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/smithy-client": "^3.2.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
+        "@aws-sdk/client-sso-oidc": "3.677.0",
+        "@aws-sdk/client-sts": "3.677.0",
+        "@aws-sdk/core": "3.677.0",
+        "@aws-sdk/credential-provider-node": "3.677.0",
+        "@aws-sdk/middleware-host-header": "3.667.0",
+        "@aws-sdk/middleware-logger": "3.667.0",
+        "@aws-sdk/middleware-recursion-detection": "3.667.0",
+        "@aws-sdk/middleware-user-agent": "3.677.0",
+        "@aws-sdk/region-config-resolver": "3.667.0",
+        "@aws-sdk/types": "3.667.0",
+        "@aws-sdk/util-endpoints": "3.667.0",
+        "@aws-sdk/util-user-agent-browser": "3.675.0",
+        "@aws-sdk/util-user-agent-node": "3.677.0",
+        "@smithy/config-resolver": "^3.0.9",
+        "@smithy/core": "^2.4.8",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/hash-node": "^3.0.7",
+        "@smithy/invalid-dependency": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.9",
+        "@smithy/middleware-endpoint": "^3.1.4",
+        "@smithy/middleware-retry": "^3.0.23",
+        "@smithy/middleware-serde": "^3.0.7",
+        "@smithy/middleware-stack": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/url-parser": "^3.0.7",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.15",
-        "@smithy/util-defaults-mode-node": "^3.0.15",
-        "@smithy/util-endpoints": "^2.0.5",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-defaults-mode-browser": "^3.0.23",
+        "@smithy/util-defaults-mode-node": "^3.0.23",
+        "@smithy/util-endpoints": "^2.1.3",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-retry": "^3.0.7",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -3989,15 +9200,45 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
-      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.667.0.tgz",
+      "integrity": "sha512-iNr+JhhA902JMKHG9IwT9YdaEx6KGl6vjAL5BRNeOjfj4cZYMog6Lz/IlfOAltMtT0w88DAHDEFrBd2uO0l2eg==",
       "dev": true,
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/types": "3.667.0",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4005,12 +9246,25 @@
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4245,6 +9499,21 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz",
+      "integrity": "sha512-ExuILJ2qLW5ZO+rgkNRj0xiAipKT16Rk77buvPP8csR7kkCflT/gXTyzRe/uzIiETTxM7tr8xuO9MP/DQXqkfg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/credential-provider-http": {
       "version": "3.622.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.622.0.tgz",
@@ -4313,6 +9582,22 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.620.1.tgz",
+      "integrity": "sha512-hWqFMidqLAkaV9G460+1at6qa9vySbjQKKc04p59OT7lZ5cO5VH5S4aI05e+m4j364MBROjjk2ugNvfNf/8ILg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/credential-provider-sso": {
       "version": "3.624.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.624.0.tgz",
@@ -4324,6 +9609,68 @@
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
         "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.621.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.621.0.tgz",
+      "integrity": "sha512-w7ASSyfNvcx7+bYGep3VBgC3K6vEdLmlpjT7nSIHxxQf+WSdvy+HynwJosrpZax0sK5q0D1Jpn/5q+r5lwwW6w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.621.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
+      "integrity": "sha512-VMtPEZwqYrII/oUkffYsNWY9PZ9xpNJpMgmyU0rlDQ25O1c0Hk3fJmZRe6pEkAJ0omD7kLrqGl1DUjQVxpd/Rg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
+      "integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz",
+      "integrity": "sha512-nh91S7aGK3e/o1ck64sA/CyoFw+gAYj2BDOnoNa6ouyCrVJED96ZXWbhye/fz9SgmNUZR2g7GdVpiLpMKZoI5w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -4347,6 +9694,55 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
+      "integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/token-providers": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
+      "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.614.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/types": {
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
+      "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/util-endpoints": {
       "version": "3.614.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.614.0.tgz",
@@ -4362,15 +9758,50 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
-      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+    "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
+      "integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
       "dev": true,
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@aws-sdk/types": "3.609.0",
         "@smithy/types": "^3.3.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
+      "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4378,12 +9809,25 @@
       }
     },
     "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4610,6 +10054,20 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz",
+      "integrity": "sha512-ExuILJ2qLW5ZO+rgkNRj0xiAipKT16Rk77buvPP8csR7kkCflT/gXTyzRe/uzIiETTxM7tr8xuO9MP/DQXqkfg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/credential-provider-http": {
       "version": "3.621.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.621.0.tgz",
@@ -4675,6 +10133,21 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.620.1.tgz",
+      "integrity": "sha512-hWqFMidqLAkaV9G460+1at6qa9vySbjQKKc04p59OT7lZ5cO5VH5S4aI05e+m4j364MBROjjk2ugNvfNf/8ILg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/credential-provider-sso": {
       "version": "3.621.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.621.0.tgz",
@@ -4685,6 +10158,64 @@
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
         "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.621.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.621.0.tgz",
+      "integrity": "sha512-w7ASSyfNvcx7+bYGep3VBgC3K6vEdLmlpjT7nSIHxxQf+WSdvy+HynwJosrpZax0sK5q0D1Jpn/5q+r5lwwW6w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.621.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
+      "integrity": "sha512-VMtPEZwqYrII/oUkffYsNWY9PZ9xpNJpMgmyU0rlDQ25O1c0Hk3fJmZRe6pEkAJ0omD7kLrqGl1DUjQVxpd/Rg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
+      "integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz",
+      "integrity": "sha512-nh91S7aGK3e/o1ck64sA/CyoFw+gAYj2BDOnoNa6ouyCrVJED96ZXWbhye/fz9SgmNUZR2g7GdVpiLpMKZoI5w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -4707,6 +10238,52 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
+      "integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/token-providers": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
+      "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.614.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/types": {
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
+      "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/util-endpoints": {
       "version": "3.614.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.614.0.tgz",
@@ -4721,14 +10298,47 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-firehose/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
-      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+    "node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
+      "integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@aws-sdk/types": "3.609.0",
         "@smithy/types": "^3.3.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
+      "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-firehose/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4736,11 +10346,23 @@
       }
     },
     "node_modules/@aws-sdk/client-firehose/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-firehose/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4973,6 +10595,21 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz",
+      "integrity": "sha512-ExuILJ2qLW5ZO+rgkNRj0xiAipKT16Rk77buvPP8csR7kkCflT/gXTyzRe/uzIiETTxM7tr8xuO9MP/DQXqkfg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/credential-provider-http": {
       "version": "3.622.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.622.0.tgz",
@@ -5041,6 +10678,22 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.620.1.tgz",
+      "integrity": "sha512-hWqFMidqLAkaV9G460+1at6qa9vySbjQKKc04p59OT7lZ5cO5VH5S4aI05e+m4j364MBROjjk2ugNvfNf/8ILg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/credential-provider-sso": {
       "version": "3.624.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.624.0.tgz",
@@ -5052,6 +10705,68 @@
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
         "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.621.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.621.0.tgz",
+      "integrity": "sha512-w7ASSyfNvcx7+bYGep3VBgC3K6vEdLmlpjT7nSIHxxQf+WSdvy+HynwJosrpZax0sK5q0D1Jpn/5q+r5lwwW6w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.621.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
+      "integrity": "sha512-VMtPEZwqYrII/oUkffYsNWY9PZ9xpNJpMgmyU0rlDQ25O1c0Hk3fJmZRe6pEkAJ0omD7kLrqGl1DUjQVxpd/Rg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
+      "integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz",
+      "integrity": "sha512-nh91S7aGK3e/o1ck64sA/CyoFw+gAYj2BDOnoNa6ouyCrVJED96ZXWbhye/fz9SgmNUZR2g7GdVpiLpMKZoI5w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -5075,6 +10790,55 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
+      "integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/token-providers": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
+      "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.614.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/types": {
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
+      "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/util-endpoints": {
       "version": "3.614.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.614.0.tgz",
@@ -5090,15 +10854,50 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
-      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
+      "integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
       "dev": true,
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@aws-sdk/types": "3.609.0",
         "@smithy/types": "^3.3.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
+      "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5106,12 +10905,25 @@
       }
     },
     "node_modules/@aws-sdk/client-iam/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5342,6 +11154,20 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz",
+      "integrity": "sha512-ExuILJ2qLW5ZO+rgkNRj0xiAipKT16Rk77buvPP8csR7kkCflT/gXTyzRe/uzIiETTxM7tr8xuO9MP/DQXqkfg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/credential-provider-http": {
       "version": "3.621.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.621.0.tgz",
@@ -5407,6 +11233,21 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.620.1.tgz",
+      "integrity": "sha512-hWqFMidqLAkaV9G460+1at6qa9vySbjQKKc04p59OT7lZ5cO5VH5S4aI05e+m4j364MBROjjk2ugNvfNf/8ILg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/credential-provider-sso": {
       "version": "3.621.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.621.0.tgz",
@@ -5417,6 +11258,64 @@
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
         "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.621.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.621.0.tgz",
+      "integrity": "sha512-w7ASSyfNvcx7+bYGep3VBgC3K6vEdLmlpjT7nSIHxxQf+WSdvy+HynwJosrpZax0sK5q0D1Jpn/5q+r5lwwW6w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.621.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
+      "integrity": "sha512-VMtPEZwqYrII/oUkffYsNWY9PZ9xpNJpMgmyU0rlDQ25O1c0Hk3fJmZRe6pEkAJ0omD7kLrqGl1DUjQVxpd/Rg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
+      "integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz",
+      "integrity": "sha512-nh91S7aGK3e/o1ck64sA/CyoFw+gAYj2BDOnoNa6ouyCrVJED96ZXWbhye/fz9SgmNUZR2g7GdVpiLpMKZoI5w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -5439,6 +11338,52 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
+      "integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/token-providers": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
+      "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.614.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/types": {
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
+      "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/util-endpoints": {
       "version": "3.614.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.614.0.tgz",
@@ -5453,14 +11398,47 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-kinesis/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
-      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+    "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
+      "integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@aws-sdk/types": "3.609.0",
         "@smithy/types": "^3.3.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
+      "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-kinesis/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5468,11 +11446,23 @@
       }
     },
     "node_modules/@aws-sdk/client-kinesis/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kinesis/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5480,56 +11470,86 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda": {
-      "version": "3.637.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.637.0.tgz",
-      "integrity": "sha512-XVQn4p/9XNMEImxCY97WlA83Q63HRrDhks4kby5YGG2fZckaNJxXE+/FFYsznse8hXKLUJ1/aI3hZSnXTthq5g==",
+      "version": "3.677.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.677.0.tgz",
+      "integrity": "sha512-b6cHfcZUmFum++PZ4N/2WyxCsfZDYOC235E+vGZX4mWhAvXoP1qbRIaPFeRxoLhvtPnf7z3G2BKBxQdQtxYEfA==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.637.0",
-        "@aws-sdk/client-sts": "3.637.0",
-        "@aws-sdk/core": "3.635.0",
-        "@aws-sdk/credential-provider-node": "3.637.0",
-        "@aws-sdk/middleware-host-header": "3.620.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.620.0",
-        "@aws-sdk/middleware-user-agent": "3.637.0",
-        "@aws-sdk/region-config-resolver": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.637.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.614.0",
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.4.0",
-        "@smithy/eventstream-serde-browser": "^3.0.6",
-        "@smithy/eventstream-serde-config-resolver": "^3.0.3",
-        "@smithy/eventstream-serde-node": "^3.0.5",
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.5",
-        "@smithy/middleware-endpoint": "^3.1.0",
-        "@smithy/middleware-retry": "^3.0.15",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/smithy-client": "^3.2.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
+        "@aws-sdk/client-sso-oidc": "3.677.0",
+        "@aws-sdk/client-sts": "3.677.0",
+        "@aws-sdk/core": "3.677.0",
+        "@aws-sdk/credential-provider-node": "3.677.0",
+        "@aws-sdk/middleware-host-header": "3.667.0",
+        "@aws-sdk/middleware-logger": "3.667.0",
+        "@aws-sdk/middleware-recursion-detection": "3.667.0",
+        "@aws-sdk/middleware-user-agent": "3.677.0",
+        "@aws-sdk/region-config-resolver": "3.667.0",
+        "@aws-sdk/types": "3.667.0",
+        "@aws-sdk/util-endpoints": "3.667.0",
+        "@aws-sdk/util-user-agent-browser": "3.675.0",
+        "@aws-sdk/util-user-agent-node": "3.677.0",
+        "@smithy/config-resolver": "^3.0.9",
+        "@smithy/core": "^2.4.8",
+        "@smithy/eventstream-serde-browser": "^3.0.10",
+        "@smithy/eventstream-serde-config-resolver": "^3.0.7",
+        "@smithy/eventstream-serde-node": "^3.0.9",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/hash-node": "^3.0.7",
+        "@smithy/invalid-dependency": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.9",
+        "@smithy/middleware-endpoint": "^3.1.4",
+        "@smithy/middleware-retry": "^3.0.23",
+        "@smithy/middleware-serde": "^3.0.7",
+        "@smithy/middleware-stack": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/url-parser": "^3.0.7",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.15",
-        "@smithy/util-defaults-mode-node": "^3.0.15",
-        "@smithy/util-endpoints": "^2.0.5",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
-        "@smithy/util-stream": "^3.1.3",
+        "@smithy/util-defaults-mode-browser": "^3.0.23",
+        "@smithy/util-defaults-mode-node": "^3.0.23",
+        "@smithy/util-endpoints": "^2.1.3",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-retry": "^3.0.7",
+        "@smithy/util-stream": "^3.1.9",
         "@smithy/util-utf8": "^3.0.0",
-        "@smithy/util-waiter": "^3.1.2",
+        "@smithy/util-waiter": "^3.1.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.667.0.tgz",
+      "integrity": "sha512-iNr+JhhA902JMKHG9IwT9YdaEx6KGl6vjAL5BRNeOjfj4cZYMog6Lz/IlfOAltMtT0w88DAHDEFrBd2uO0l2eg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.667.0",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5537,14 +11557,14 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
-      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
       "dev": true,
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5552,12 +11572,25 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5784,6 +11817,20 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz",
+      "integrity": "sha512-ExuILJ2qLW5ZO+rgkNRj0xiAipKT16Rk77buvPP8csR7kkCflT/gXTyzRe/uzIiETTxM7tr8xuO9MP/DQXqkfg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/credential-provider-http": {
       "version": "3.621.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.621.0.tgz",
@@ -5849,6 +11896,21 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.620.1.tgz",
+      "integrity": "sha512-hWqFMidqLAkaV9G460+1at6qa9vySbjQKKc04p59OT7lZ5cO5VH5S4aI05e+m4j364MBROjjk2ugNvfNf/8ILg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/credential-provider-sso": {
       "version": "3.621.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.621.0.tgz",
@@ -5859,6 +11921,64 @@
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
         "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.621.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.621.0.tgz",
+      "integrity": "sha512-w7ASSyfNvcx7+bYGep3VBgC3K6vEdLmlpjT7nSIHxxQf+WSdvy+HynwJosrpZax0sK5q0D1Jpn/5q+r5lwwW6w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.621.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
+      "integrity": "sha512-VMtPEZwqYrII/oUkffYsNWY9PZ9xpNJpMgmyU0rlDQ25O1c0Hk3fJmZRe6pEkAJ0omD7kLrqGl1DUjQVxpd/Rg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
+      "integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz",
+      "integrity": "sha512-nh91S7aGK3e/o1ck64sA/CyoFw+gAYj2BDOnoNa6ouyCrVJED96ZXWbhye/fz9SgmNUZR2g7GdVpiLpMKZoI5w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -5881,6 +12001,52 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
+      "integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/token-providers": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
+      "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.614.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/types": {
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
+      "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/util-endpoints": {
       "version": "3.614.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.614.0.tgz",
@@ -5895,14 +12061,47 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-personalize-events/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
-      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+    "node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
+      "integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@aws-sdk/types": "3.609.0",
         "@smithy/types": "^3.3.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
+      "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-personalize-events/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5910,11 +12109,23 @@
       }
     },
     "node_modules/@aws-sdk/client-personalize-events/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-personalize-events/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6148,6 +12359,21 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-rds/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz",
+      "integrity": "sha512-ExuILJ2qLW5ZO+rgkNRj0xiAipKT16Rk77buvPP8csR7kkCflT/gXTyzRe/uzIiETTxM7tr8xuO9MP/DQXqkfg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-rds/node_modules/@aws-sdk/credential-provider-http": {
       "version": "3.622.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.622.0.tgz",
@@ -6216,6 +12442,22 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-rds/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.620.1.tgz",
+      "integrity": "sha512-hWqFMidqLAkaV9G460+1at6qa9vySbjQKKc04p59OT7lZ5cO5VH5S4aI05e+m4j364MBROjjk2ugNvfNf/8ILg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-rds/node_modules/@aws-sdk/credential-provider-sso": {
       "version": "3.624.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.624.0.tgz",
@@ -6227,6 +12469,68 @@
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
         "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.621.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.621.0.tgz",
+      "integrity": "sha512-w7ASSyfNvcx7+bYGep3VBgC3K6vEdLmlpjT7nSIHxxQf+WSdvy+HynwJosrpZax0sK5q0D1Jpn/5q+r5lwwW6w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.621.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
+      "integrity": "sha512-VMtPEZwqYrII/oUkffYsNWY9PZ9xpNJpMgmyU0rlDQ25O1c0Hk3fJmZRe6pEkAJ0omD7kLrqGl1DUjQVxpd/Rg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
+      "integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz",
+      "integrity": "sha512-nh91S7aGK3e/o1ck64sA/CyoFw+gAYj2BDOnoNa6ouyCrVJED96ZXWbhye/fz9SgmNUZR2g7GdVpiLpMKZoI5w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -6250,6 +12554,55 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-rds/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
+      "integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@aws-sdk/token-providers": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
+      "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.614.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@aws-sdk/types": {
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
+      "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-rds/node_modules/@aws-sdk/util-endpoints": {
       "version": "3.614.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.614.0.tgz",
@@ -6265,15 +12618,50 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
-      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+    "node_modules/@aws-sdk/client-rds/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
+      "integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
       "dev": true,
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
+        "@aws-sdk/types": "3.609.0",
         "@smithy/types": "^3.3.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
+      "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.609.0",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6281,12 +12669,25 @@
       }
     },
     "node_modules/@aws-sdk/client-rds/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6294,68 +12695,98 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.637.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.637.0.tgz",
-      "integrity": "sha512-y6UC94fsMvhKbf0dzfnjVP1HePeGjplfcYfilZU1COIJLyTkMcUv4XcT4I407CGIrvgEafONHkiC09ygqUauNA==",
+      "version": "3.677.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.677.0.tgz",
+      "integrity": "sha512-TrfT7hyjs0FRh5MosduFZsskHhjvBKL451Wo5f80IcnxvNL8YZouh6kblUSiHKUxuc32WSiAKbXJJaPWdXs75Q==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.637.0",
-        "@aws-sdk/client-sts": "3.637.0",
-        "@aws-sdk/core": "3.635.0",
-        "@aws-sdk/credential-provider-node": "3.637.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.620.0",
-        "@aws-sdk/middleware-expect-continue": "3.620.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.620.0",
-        "@aws-sdk/middleware-host-header": "3.620.0",
-        "@aws-sdk/middleware-location-constraint": "3.609.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.620.0",
-        "@aws-sdk/middleware-sdk-s3": "3.635.0",
-        "@aws-sdk/middleware-ssec": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.637.0",
-        "@aws-sdk/region-config-resolver": "3.614.0",
-        "@aws-sdk/signature-v4-multi-region": "3.635.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.637.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.614.0",
-        "@aws-sdk/xml-builder": "3.609.0",
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.4.0",
-        "@smithy/eventstream-serde-browser": "^3.0.6",
-        "@smithy/eventstream-serde-config-resolver": "^3.0.3",
-        "@smithy/eventstream-serde-node": "^3.0.5",
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/hash-blob-browser": "^3.1.2",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/hash-stream-node": "^3.1.2",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/md5-js": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.5",
-        "@smithy/middleware-endpoint": "^3.1.0",
-        "@smithy/middleware-retry": "^3.0.15",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/smithy-client": "^3.2.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
+        "@aws-sdk/client-sso-oidc": "3.677.0",
+        "@aws-sdk/client-sts": "3.677.0",
+        "@aws-sdk/core": "3.677.0",
+        "@aws-sdk/credential-provider-node": "3.677.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.667.0",
+        "@aws-sdk/middleware-expect-continue": "3.667.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.677.0",
+        "@aws-sdk/middleware-host-header": "3.667.0",
+        "@aws-sdk/middleware-location-constraint": "3.667.0",
+        "@aws-sdk/middleware-logger": "3.667.0",
+        "@aws-sdk/middleware-recursion-detection": "3.667.0",
+        "@aws-sdk/middleware-sdk-s3": "3.677.0",
+        "@aws-sdk/middleware-ssec": "3.667.0",
+        "@aws-sdk/middleware-user-agent": "3.677.0",
+        "@aws-sdk/region-config-resolver": "3.667.0",
+        "@aws-sdk/signature-v4-multi-region": "3.677.0",
+        "@aws-sdk/types": "3.667.0",
+        "@aws-sdk/util-endpoints": "3.667.0",
+        "@aws-sdk/util-user-agent-browser": "3.675.0",
+        "@aws-sdk/util-user-agent-node": "3.677.0",
+        "@aws-sdk/xml-builder": "3.662.0",
+        "@smithy/config-resolver": "^3.0.9",
+        "@smithy/core": "^2.4.8",
+        "@smithy/eventstream-serde-browser": "^3.0.10",
+        "@smithy/eventstream-serde-config-resolver": "^3.0.7",
+        "@smithy/eventstream-serde-node": "^3.0.9",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/hash-blob-browser": "^3.1.6",
+        "@smithy/hash-node": "^3.0.7",
+        "@smithy/hash-stream-node": "^3.1.6",
+        "@smithy/invalid-dependency": "^3.0.7",
+        "@smithy/md5-js": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.9",
+        "@smithy/middleware-endpoint": "^3.1.4",
+        "@smithy/middleware-retry": "^3.0.23",
+        "@smithy/middleware-serde": "^3.0.7",
+        "@smithy/middleware-stack": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/url-parser": "^3.0.7",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.15",
-        "@smithy/util-defaults-mode-node": "^3.0.15",
-        "@smithy/util-endpoints": "^2.0.5",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
-        "@smithy/util-stream": "^3.1.3",
+        "@smithy/util-defaults-mode-browser": "^3.0.23",
+        "@smithy/util-defaults-mode-node": "^3.0.23",
+        "@smithy/util-endpoints": "^2.1.3",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-retry": "^3.0.7",
+        "@smithy/util-stream": "^3.1.9",
         "@smithy/util-utf8": "^3.0.0",
-        "@smithy/util-waiter": "^3.1.2",
+        "@smithy/util-waiter": "^3.1.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.667.0.tgz",
+      "integrity": "sha512-iNr+JhhA902JMKHG9IwT9YdaEx6KGl6vjAL5BRNeOjfj4cZYMog6Lz/IlfOAltMtT0w88DAHDEFrBd2uO0l2eg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.667.0",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6363,14 +12794,14 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
-      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
       "dev": true,
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6378,12 +12809,25 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6391,52 +12835,53 @@
       }
     },
     "node_modules/@aws-sdk/client-ssm": {
-      "version": "3.637.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.637.0.tgz",
-      "integrity": "sha512-cr0/c95KpFIwoCCofXu1Em/Sw8SjIFCZ3X1ji2rW81QdLpw7icP01SMcRTbgtiKeN12fKZDXmrupkI6zhnG0MA==",
+      "version": "3.677.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.677.0.tgz",
+      "integrity": "sha512-LkBdQ50Zgbx24DCxXp+reP5AayUxFpx+ryDiwBCvc5mOjG0JvYMKwEoYqCC93rxAttrfY8Cr7h8YuGDmOry6lw==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.637.0",
-        "@aws-sdk/client-sts": "3.637.0",
-        "@aws-sdk/core": "3.635.0",
-        "@aws-sdk/credential-provider-node": "3.637.0",
-        "@aws-sdk/middleware-host-header": "3.620.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.620.0",
-        "@aws-sdk/middleware-user-agent": "3.637.0",
-        "@aws-sdk/region-config-resolver": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.637.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.614.0",
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.4.0",
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.5",
-        "@smithy/middleware-endpoint": "^3.1.0",
-        "@smithy/middleware-retry": "^3.0.15",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/smithy-client": "^3.2.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
+        "@aws-sdk/client-sso-oidc": "3.677.0",
+        "@aws-sdk/client-sts": "3.677.0",
+        "@aws-sdk/core": "3.677.0",
+        "@aws-sdk/credential-provider-node": "3.677.0",
+        "@aws-sdk/middleware-host-header": "3.667.0",
+        "@aws-sdk/middleware-logger": "3.667.0",
+        "@aws-sdk/middleware-recursion-detection": "3.667.0",
+        "@aws-sdk/middleware-user-agent": "3.677.0",
+        "@aws-sdk/region-config-resolver": "3.667.0",
+        "@aws-sdk/types": "3.667.0",
+        "@aws-sdk/util-endpoints": "3.667.0",
+        "@aws-sdk/util-user-agent-browser": "3.675.0",
+        "@aws-sdk/util-user-agent-node": "3.677.0",
+        "@smithy/config-resolver": "^3.0.9",
+        "@smithy/core": "^2.4.8",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/hash-node": "^3.0.7",
+        "@smithy/invalid-dependency": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.9",
+        "@smithy/middleware-endpoint": "^3.1.4",
+        "@smithy/middleware-retry": "^3.0.23",
+        "@smithy/middleware-serde": "^3.0.7",
+        "@smithy/middleware-stack": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/url-parser": "^3.0.7",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.15",
-        "@smithy/util-defaults-mode-node": "^3.0.15",
-        "@smithy/util-endpoints": "^2.0.5",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-defaults-mode-browser": "^3.0.23",
+        "@smithy/util-defaults-mode-node": "^3.0.23",
+        "@smithy/util-endpoints": "^2.1.3",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-retry": "^3.0.7",
         "@smithy/util-utf8": "^3.0.0",
-        "@smithy/util-waiter": "^3.1.2",
+        "@smithy/util-waiter": "^3.1.6",
+        "@types/uuid": "^9.0.1",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
       },
@@ -6444,15 +12889,45 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
-      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.667.0.tgz",
+      "integrity": "sha512-iNr+JhhA902JMKHG9IwT9YdaEx6KGl6vjAL5BRNeOjfj4cZYMog6Lz/IlfOAltMtT0w88DAHDEFrBd2uO0l2eg==",
       "dev": true,
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/types": "3.667.0",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6460,12 +12935,25 @@
       }
     },
     "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6473,46 +12961,47 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.637.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.637.0.tgz",
-      "integrity": "sha512-+KjLvgX5yJYROWo3TQuwBJlHCY0zz9PsLuEolmXQn0BVK1L/m9GteZHtd+rEdAoDGBpE0Xqjy1oz5+SmtsaRUw==",
+      "version": "3.677.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.677.0.tgz",
+      "integrity": "sha512-/y6EskFhOa2w9VwXaXoyOrGeBjnOj/72wsxDOslS908qH+nf7m40pBK6e/iBelg04vlx0gqhlbfK8hLbaT6KHA==",
+      "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.635.0",
-        "@aws-sdk/middleware-host-header": "3.620.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.620.0",
-        "@aws-sdk/middleware-user-agent": "3.637.0",
-        "@aws-sdk/region-config-resolver": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.637.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.614.0",
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.4.0",
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.5",
-        "@smithy/middleware-endpoint": "^3.1.0",
-        "@smithy/middleware-retry": "^3.0.15",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/smithy-client": "^3.2.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
+        "@aws-sdk/core": "3.677.0",
+        "@aws-sdk/middleware-host-header": "3.667.0",
+        "@aws-sdk/middleware-logger": "3.667.0",
+        "@aws-sdk/middleware-recursion-detection": "3.667.0",
+        "@aws-sdk/middleware-user-agent": "3.677.0",
+        "@aws-sdk/region-config-resolver": "3.667.0",
+        "@aws-sdk/types": "3.667.0",
+        "@aws-sdk/util-endpoints": "3.667.0",
+        "@aws-sdk/util-user-agent-browser": "3.675.0",
+        "@aws-sdk/util-user-agent-node": "3.677.0",
+        "@smithy/config-resolver": "^3.0.9",
+        "@smithy/core": "^2.4.8",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/hash-node": "^3.0.7",
+        "@smithy/invalid-dependency": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.9",
+        "@smithy/middleware-endpoint": "^3.1.4",
+        "@smithy/middleware-retry": "^3.0.23",
+        "@smithy/middleware-serde": "^3.0.7",
+        "@smithy/middleware-stack": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/url-parser": "^3.0.7",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.15",
-        "@smithy/util-defaults-mode-node": "^3.0.15",
-        "@smithy/util-endpoints": "^2.0.5",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-defaults-mode-browser": "^3.0.23",
+        "@smithy/util-defaults-mode-node": "^3.0.23",
+        "@smithy/util-endpoints": "^2.1.3",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-retry": "^3.0.7",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -6521,47 +13010,48 @@
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.637.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.637.0.tgz",
-      "integrity": "sha512-27bHALN6Qb6m6KZmPvRieJ/QRlj1lyac/GT2Rn5kJpre8Mpp+yxrtvp3h9PjNBty4lCeFEENfY4dGNSozBuBcw==",
+      "version": "3.677.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.677.0.tgz",
+      "integrity": "sha512-2zgZkRIU7DsnUVOy+9bjfJ0IYMzi9ONWXQt/WqMa7HOnj4RfenfpipyhHYxGZR5kmehgv53EI79yvUu+SAfGNg==",
+      "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.635.0",
-        "@aws-sdk/credential-provider-node": "3.637.0",
-        "@aws-sdk/middleware-host-header": "3.620.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.620.0",
-        "@aws-sdk/middleware-user-agent": "3.637.0",
-        "@aws-sdk/region-config-resolver": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.637.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.614.0",
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.4.0",
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.5",
-        "@smithy/middleware-endpoint": "^3.1.0",
-        "@smithy/middleware-retry": "^3.0.15",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/smithy-client": "^3.2.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
+        "@aws-sdk/core": "3.677.0",
+        "@aws-sdk/credential-provider-node": "3.677.0",
+        "@aws-sdk/middleware-host-header": "3.667.0",
+        "@aws-sdk/middleware-logger": "3.667.0",
+        "@aws-sdk/middleware-recursion-detection": "3.667.0",
+        "@aws-sdk/middleware-user-agent": "3.677.0",
+        "@aws-sdk/region-config-resolver": "3.667.0",
+        "@aws-sdk/types": "3.667.0",
+        "@aws-sdk/util-endpoints": "3.667.0",
+        "@aws-sdk/util-user-agent-browser": "3.675.0",
+        "@aws-sdk/util-user-agent-node": "3.677.0",
+        "@smithy/config-resolver": "^3.0.9",
+        "@smithy/core": "^2.4.8",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/hash-node": "^3.0.7",
+        "@smithy/invalid-dependency": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.9",
+        "@smithy/middleware-endpoint": "^3.1.4",
+        "@smithy/middleware-retry": "^3.0.23",
+        "@smithy/middleware-serde": "^3.0.7",
+        "@smithy/middleware-stack": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/url-parser": "^3.0.7",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.15",
-        "@smithy/util-defaults-mode-node": "^3.0.15",
-        "@smithy/util-endpoints": "^2.0.5",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-defaults-mode-browser": "^3.0.23",
+        "@smithy/util-defaults-mode-node": "^3.0.23",
+        "@smithy/util-endpoints": "^2.1.3",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-retry": "^3.0.7",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -6569,17 +13059,48 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.637.0"
+        "@aws-sdk/client-sts": "^3.677.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.667.0.tgz",
+      "integrity": "sha512-iNr+JhhA902JMKHG9IwT9YdaEx6KGl6vjAL5BRNeOjfj4cZYMog6Lz/IlfOAltMtT0w88DAHDEFrBd2uO0l2eg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.667.0",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
-      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
+      "dev": true,
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6587,11 +13108,55 @@
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
+      "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.667.0.tgz",
+      "integrity": "sha512-iNr+JhhA902JMKHG9IwT9YdaEx6KGl6vjAL5BRNeOjfj4cZYMog6Lz/IlfOAltMtT0w88DAHDEFrBd2uO0l2eg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.667.0",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6599,13 +13164,14 @@
       }
     },
     "node_modules/@aws-sdk/client-sso/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
-      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
+      "dev": true,
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6613,11 +13179,25 @@
       }
     },
     "node_modules/@aws-sdk/client-sso/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
+      "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6625,49 +13205,80 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.637.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.637.0.tgz",
-      "integrity": "sha512-xUi7x4qDubtA8QREtlblPuAcn91GS/09YVEY/RwU7xCY0aqGuFwgszAANlha4OUIqva8oVj2WO4gJuG+iaSnhw==",
+      "version": "3.677.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.677.0.tgz",
+      "integrity": "sha512-N5fs1GLSthnwrs44b4IJI//dcShuIT42g4pM8FCUJZwbrWn9Sp9F876R1mvb8A9TAy2S4qCXi7TkHS0REnuicQ==",
+      "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.637.0",
-        "@aws-sdk/core": "3.635.0",
-        "@aws-sdk/credential-provider-node": "3.637.0",
-        "@aws-sdk/middleware-host-header": "3.620.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.620.0",
-        "@aws-sdk/middleware-user-agent": "3.637.0",
-        "@aws-sdk/region-config-resolver": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.637.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.614.0",
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.4.0",
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.5",
-        "@smithy/middleware-endpoint": "^3.1.0",
-        "@smithy/middleware-retry": "^3.0.15",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/smithy-client": "^3.2.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
+        "@aws-sdk/client-sso-oidc": "3.677.0",
+        "@aws-sdk/core": "3.677.0",
+        "@aws-sdk/credential-provider-node": "3.677.0",
+        "@aws-sdk/middleware-host-header": "3.667.0",
+        "@aws-sdk/middleware-logger": "3.667.0",
+        "@aws-sdk/middleware-recursion-detection": "3.667.0",
+        "@aws-sdk/middleware-user-agent": "3.677.0",
+        "@aws-sdk/region-config-resolver": "3.667.0",
+        "@aws-sdk/types": "3.667.0",
+        "@aws-sdk/util-endpoints": "3.667.0",
+        "@aws-sdk/util-user-agent-browser": "3.675.0",
+        "@aws-sdk/util-user-agent-node": "3.677.0",
+        "@smithy/config-resolver": "^3.0.9",
+        "@smithy/core": "^2.4.8",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/hash-node": "^3.0.7",
+        "@smithy/invalid-dependency": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.9",
+        "@smithy/middleware-endpoint": "^3.1.4",
+        "@smithy/middleware-retry": "^3.0.23",
+        "@smithy/middleware-serde": "^3.0.7",
+        "@smithy/middleware-stack": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/url-parser": "^3.0.7",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.15",
-        "@smithy/util-defaults-mode-node": "^3.0.15",
-        "@smithy/util-endpoints": "^2.0.5",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-defaults-mode-browser": "^3.0.23",
+        "@smithy/util-defaults-mode-node": "^3.0.23",
+        "@smithy/util-endpoints": "^2.1.3",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-retry": "^3.0.7",
         "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.667.0.tgz",
+      "integrity": "sha512-iNr+JhhA902JMKHG9IwT9YdaEx6KGl6vjAL5BRNeOjfj4cZYMog6Lz/IlfOAltMtT0w88DAHDEFrBd2uO0l2eg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.667.0",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6675,13 +13286,14 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
-      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
+      "dev": true,
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6689,11 +13301,25 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
+      "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6701,18 +13327,20 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.635.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.635.0.tgz",
-      "integrity": "sha512-i1x/E/sgA+liUE1XJ7rj1dhyXpAKO1UKFUcTTHXok2ARjWTvszHnSXMOsB77aPbmn0fUp1JTx2kHUAZ1LVt5Bg==",
+      "version": "3.677.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.677.0.tgz",
+      "integrity": "sha512-5auvc1wmXmd7u9Y9nM95Ia+VX7J2FiZLuADitHqE4mHPH9riDgOY+uK/yM+UKr+lfq4zKiZQG7i8cfabZlCY8g==",
+      "dev": true,
       "dependencies": {
-        "@smithy/core": "^2.4.0",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/signature-v4": "^4.1.0",
-        "@smithy/smithy-client": "^3.2.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-middleware": "^3.0.3",
+        "@aws-sdk/types": "3.667.0",
+        "@smithy/core": "^2.4.8",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/signature-v4": "^4.2.0",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-middleware": "^3.0.7",
         "fast-xml-parser": "4.4.1",
         "tslib": "^2.6.2"
       },
@@ -6720,14 +13348,28 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/core/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
-      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+    "node_modules/@aws-sdk/core/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6735,11 +13377,12 @@
       }
     },
     "node_modules/@aws-sdk/core/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
+      "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6747,15 +13390,28 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.637.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.637.0.tgz",
-      "integrity": "sha512-9qK1mF+EThtv3tsL1C/wb9MpWctJSkzjrLTFj+0Rtk8VYm6DlGepo/I6a2x3SeDmdBfHAFSrKFU39GqWDp1mwQ==",
+      "version": "3.677.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.677.0.tgz",
+      "integrity": "sha512-ODw8MKhT41KLpKlGIH1yFO2FIOCAW3Nnn2uCu1eAm807aI0OK31ntUNrY+GFzXX7ixv+KFoiJu3ih+w+Oxw5gA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.637.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/client-cognito-identity": "3.677.0",
+        "@aws-sdk/types": "3.667.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6763,13 +13419,28 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.620.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz",
-      "integrity": "sha512-ExuILJ2qLW5ZO+rgkNRj0xiAipKT16Rk77buvPP8csR7kkCflT/gXTyzRe/uzIiETTxM7tr8xuO9MP/DQXqkfg==",
+      "version": "3.677.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.677.0.tgz",
+      "integrity": "sha512-0ctcqKzclr9TiNIkB8I+YRogjWH/4mLWQGv/bgb8ElHqph+rPy4pOubj1Ax01sbs7XdwDaImjBYV5xXE+BEsYw==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "3.677.0",
+        "@aws-sdk/types": "3.667.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6777,18 +13448,33 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.635.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.635.0.tgz",
-      "integrity": "sha512-iJyRgEjOCQlBMXqtwPLIKYc7Bsc6nqjrZybdMDenPDa+kmLg7xh8LxHsu9088e+2/wtLicE34FsJJIfzu3L82g==",
+      "version": "3.677.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.677.0.tgz",
+      "integrity": "sha512-c4TnShdzk37dhL1HGGzZ2PDKIIEmo1IbT/4y5hSRdNc8Z8fu6spE5GoeVsv6p/HdSGPS7XTy6aOFCMCk4AeIzQ==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/smithy-client": "^3.2.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-stream": "^3.1.3",
+        "@aws-sdk/core": "3.677.0",
+        "@aws-sdk/types": "3.667.0",
+        "@smithy/fetch-http-handler": "^3.2.9",
+        "@smithy/node-http-handler": "^3.2.4",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-stream": "^3.1.9",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6796,35 +13482,51 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.637.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.637.0.tgz",
-      "integrity": "sha512-h+PFCWfZ0Q3Dx84SppET/TFpcQHmxFW8/oV9ArEvMilw4EBN+IlxgbL0CnHwjHW64szcmrM0mbebjEfHf4FXmw==",
+      "version": "3.677.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.677.0.tgz",
+      "integrity": "sha512-hW+oHj5zplPLzTk74LG+gZVOKQnmBPyRIbwg3uZWr23xfOxh/Osu9Wq8qwgu2+UyFHr+6/DRFjZJ6avNA2jpKw==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.620.1",
-        "@aws-sdk/credential-provider-http": "3.635.0",
-        "@aws-sdk/credential-provider-process": "3.620.1",
-        "@aws-sdk/credential-provider-sso": "3.637.0",
-        "@aws-sdk/credential-provider-web-identity": "3.621.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.2.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "3.677.0",
+        "@aws-sdk/credential-provider-env": "3.677.0",
+        "@aws-sdk/credential-provider-http": "3.677.0",
+        "@aws-sdk/credential-provider-process": "3.677.0",
+        "@aws-sdk/credential-provider-sso": "3.677.0",
+        "@aws-sdk/credential-provider-web-identity": "3.677.0",
+        "@aws-sdk/types": "3.667.0",
+        "@smithy/credential-provider-imds": "^3.2.4",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.637.0"
+        "@aws-sdk/client-sts": "^3.677.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
+      "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6832,21 +13534,35 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.637.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.637.0.tgz",
-      "integrity": "sha512-yoEhoxJJfs7sPVQ6Is939BDQJZpZCoUgKr/ySse4YKOZ24t4VqgHA6+wV7rYh+7IW24Rd91UTvEzSuHYTlxlNA==",
+      "version": "3.677.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.677.0.tgz",
+      "integrity": "sha512-DwFriiDx2SSdj7VhRv/0fm8UIK7isy+WZAlqUdZ9xDsX4x1AD5KwMv9AwGhJrMuTjnPSxRSwjt23S7ZXwUfhdw==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.620.1",
-        "@aws-sdk/credential-provider-http": "3.635.0",
-        "@aws-sdk/credential-provider-ini": "3.637.0",
-        "@aws-sdk/credential-provider-process": "3.620.1",
-        "@aws-sdk/credential-provider-sso": "3.637.0",
-        "@aws-sdk/credential-provider-web-identity": "3.621.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.2.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/credential-provider-env": "3.677.0",
+        "@aws-sdk/credential-provider-http": "3.677.0",
+        "@aws-sdk/credential-provider-ini": "3.677.0",
+        "@aws-sdk/credential-provider-process": "3.677.0",
+        "@aws-sdk/credential-provider-sso": "3.677.0",
+        "@aws-sdk/credential-provider-web-identity": "3.677.0",
+        "@aws-sdk/types": "3.667.0",
+        "@smithy/credential-provider-imds": "^3.2.4",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6854,11 +13570,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
+      "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6866,14 +13583,29 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.620.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.620.1.tgz",
-      "integrity": "sha512-hWqFMidqLAkaV9G460+1at6qa9vySbjQKKc04p59OT7lZ5cO5VH5S4aI05e+m4j364MBROjjk2ugNvfNf/8ILg==",
+      "version": "3.677.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.677.0.tgz",
+      "integrity": "sha512-pBqHjIFvHBJb2NOsVqdIHWcOzXDoNXBokxTvMggb3WYML6ixwrH7kpd1CAzegeQlvZD4SCcRoy3ahv5rbuR+og==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "3.677.0",
+        "@aws-sdk/types": "3.667.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6881,11 +13613,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
+      "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6893,16 +13626,31 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.637.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.637.0.tgz",
-      "integrity": "sha512-Mvz+h+e62/tl+dVikLafhv+qkZJ9RUb8l2YN/LeKMWkxQylPT83CPk9aimVhCV89zth1zpREArl97+3xsfgQvA==",
+      "version": "3.677.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.677.0.tgz",
+      "integrity": "sha512-OkRP3z8yI22t9LS9At5fYr6RN7zKSDiGgeyjEnrqiGHOWGPMJN2GKa8IAFC4dgXt4Nm/EfmEW7UweiqzEKJKOA==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/client-sso": "3.637.0",
-        "@aws-sdk/token-providers": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/client-sso": "3.677.0",
+        "@aws-sdk/core": "3.677.0",
+        "@aws-sdk/token-providers": "3.667.0",
+        "@aws-sdk/types": "3.667.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6910,11 +13658,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
+      "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6922,43 +13671,72 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.621.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.621.0.tgz",
-      "integrity": "sha512-w7ASSyfNvcx7+bYGep3VBgC3K6vEdLmlpjT7nSIHxxQf+WSdvy+HynwJosrpZax0sK5q0D1Jpn/5q+r5lwwW6w==",
+      "version": "3.677.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.677.0.tgz",
+      "integrity": "sha512-yjuI6hSt1rLFqBQiNKx/nF75Ao72xR8ybqKztzebtFNCrYl8oXVkRiigg5XKNCDmelsx1lcU9IcSiuPHzlGtUQ==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "3.677.0",
+        "@aws-sdk/types": "3.667.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/types": "^3.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.621.0"
+        "@aws-sdk/client-sts": "^3.677.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.637.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.637.0.tgz",
-      "integrity": "sha512-yW1scL3Z7JsrTrmhjyZsB6tsMJ49UCO42BGlNWZAW+kN1vNJ+qbv6XYQJWR4gjpuD2rdmtGcEawcgllE2Bmigw==",
+      "version": "3.677.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.677.0.tgz",
+      "integrity": "sha512-fUEDkRI2GuN+p9xyZewlRQC2vFXjxPOoQGugQTmOawTxVUYkFpssg4ID0HUtkKuJYHjaoD2bCyKvOcnL1JU6AA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.637.0",
-        "@aws-sdk/client-sso": "3.637.0",
-        "@aws-sdk/client-sts": "3.637.0",
-        "@aws-sdk/credential-provider-cognito-identity": "3.637.0",
-        "@aws-sdk/credential-provider-env": "3.620.1",
-        "@aws-sdk/credential-provider-http": "3.635.0",
-        "@aws-sdk/credential-provider-ini": "3.637.0",
-        "@aws-sdk/credential-provider-node": "3.637.0",
-        "@aws-sdk/credential-provider-process": "3.620.1",
-        "@aws-sdk/credential-provider-sso": "3.637.0",
-        "@aws-sdk/credential-provider-web-identity": "3.621.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.2.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/client-cognito-identity": "3.677.0",
+        "@aws-sdk/client-sso": "3.677.0",
+        "@aws-sdk/client-sts": "3.677.0",
+        "@aws-sdk/core": "3.677.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.677.0",
+        "@aws-sdk/credential-provider-env": "3.677.0",
+        "@aws-sdk/credential-provider-http": "3.677.0",
+        "@aws-sdk/credential-provider-ini": "3.677.0",
+        "@aws-sdk/credential-provider-node": "3.677.0",
+        "@aws-sdk/credential-provider-process": "3.677.0",
+        "@aws-sdk/credential-provider-sso": "3.677.0",
+        "@aws-sdk/credential-provider-web-identity": "3.677.0",
+        "@aws-sdk/types": "3.667.0",
+        "@smithy/credential-provider-imds": "^3.2.4",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6966,16 +13744,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.620.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.620.0.tgz",
-      "integrity": "sha512-eGLL0W6L3HDb3OACyetZYOWpHJ+gLo0TehQKeQyy2G8vTYXqNTeqYhuI6up9HVjBzU9eQiULVQETmgQs7TFaRg==",
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.667.0.tgz",
+      "integrity": "sha512-XGz4jMAkDoTyFdtLz7ZF+C05IAhCTC1PllpvTBaj821z/L0ilhbqVhrT/f2Buw8Id/K5A390csGXgusXyrFFjA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/types": "3.667.0",
         "@aws-sdk/util-arn-parser": "3.568.0",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/types": "^3.3.0",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/types": "^3.5.0",
         "@smithy/util-config-provider": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -6983,15 +13761,28 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
-      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+    "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
       "dev": true,
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6999,12 +13790,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7012,14 +13803,27 @@
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.620.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.620.0.tgz",
-      "integrity": "sha512-QXeRFMLfyQ31nAHLbiTLtk0oHzG9QLMaof5jIfqcUwnOkO8YnQdeqzakrg1Alpy/VQ7aqzIi8qypkBe2KXZz0A==",
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.667.0.tgz",
+      "integrity": "sha512-0TiSL9S5DSG95NHGIz6qTMuV7GDKVn8tvvGSrSSZu/wXO3JaYSH0AElVpYfc4PtPRqVpEyNA7nnc7W56mMCLWQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/types": "3.667.0",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7027,17 +13831,20 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.620.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.620.0.tgz",
-      "integrity": "sha512-ftz+NW7qka2sVuwnnO1IzBku5ccP+s5qZGeRTPgrKB7OzRW85gthvIo1vQR2w+OwHFk7WJbbhhWwbCbktnP4UA==",
+      "version": "3.677.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.677.0.tgz",
+      "integrity": "sha512-mTv3zRH+3/hW8hY0K855UrBmzW4pLb7n8MjlyL2dR8+wfXXw6DsSxGmEb4Jq13OjLTwSxyZs00JdpKtzgiIieA==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
         "@aws-crypto/crc32c": "5.2.0",
-        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/core": "3.677.0",
+        "@aws-sdk/types": "3.667.0",
         "@smithy/is-array-buffer": "^3.0.0",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/types": "^3.3.0",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-middleware": "^3.0.7",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -7045,14 +13852,82 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.620.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
-      "integrity": "sha512-VMtPEZwqYrII/oUkffYsNWY9PZ9xpNJpMgmyU0rlDQ25O1c0Hk3fJmZRe6pEkAJ0omD7kLrqGl1DUjQVxpd/Rg==",
+    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.667.0.tgz",
+      "integrity": "sha512-Z7fIAMQnPegs7JjAQvlOeWXwpMRfegh5eCoIP6VLJIeR6DLfYKbP35JBtt98R6DXslrN2RsbTogjbxPEDQfw1w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.667.0",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7060,13 +13935,26 @@
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.609.0.tgz",
-      "integrity": "sha512-xzsdoTkszGVqGVPjUmgoP7TORiByLueMHieI1fhQL888WPdqctwAx3ES6d/bA9Q/i8jnc6hs+Fjhy8UvBTkE9A==",
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.667.0.tgz",
+      "integrity": "sha512-ob85H3HhT3/u5O+x0o557xGZ78vSNeSSwMaSitxdsfs2hOuoUl1uk+OeLpi1hkuJnL41FPpokV7TVII2XrFfmg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/types": "3.667.0",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7074,12 +13962,26 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
-      "integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.667.0.tgz",
+      "integrity": "sha512-PtTRNpNm/5c746jRgZCNg4X9xEJIwggkGJrF0GP9AB1ANg4pc/sF2Fvn1NtqPe9wtQ2stunJprnm5WkCHN7QiA==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/types": "3.667.0",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7087,13 +13989,27 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.620.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz",
-      "integrity": "sha512-nh91S7aGK3e/o1ck64sA/CyoFw+gAYj2BDOnoNa6ouyCrVJED96ZXWbhye/fz9SgmNUZR2g7GdVpiLpMKZoI5w==",
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.667.0.tgz",
+      "integrity": "sha512-U5glWD3ehFohzpUpopLtmqAlDurGWo2wRGPNgi4SwhWU7UDt6LS7E/UvJjqC0CUrjlzOw+my2A+Ncf+fisMhxQ==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/types": "3.667.0",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7119,6 +14035,19 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-sdk/middleware-sdk-ec2/node_modules/@aws-sdk/types": {
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
+      "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-sdk-rds": {
       "version": "3.620.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-rds/-/middleware-sdk-rds-3.620.0.tgz",
@@ -7137,24 +14066,37 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.635.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.635.0.tgz",
-      "integrity": "sha512-RLdYJPEV4JL/7NBoFUs7VlP90X++5FlJdxHz0DzCjmiD3qCviKy+Cym3qg1gBgHwucs5XisuClxDrGokhAdTQw==",
+    "node_modules/@aws-sdk/middleware-sdk-rds/node_modules/@aws-sdk/types": {
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
+      "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/core": "3.635.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-arn-parser": "3.568.0",
-        "@smithy/core": "^2.4.0",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/signature-v4": "^4.1.0",
-        "@smithy/smithy-client": "^3.2.0",
         "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.677.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.677.0.tgz",
+      "integrity": "sha512-3U8FHgWuxhAl97HMdaFs/SJlhpb5+i//FHv0JWYm2oAPZflIRFeJn1bgVtD7ka1NY2iJjpnqX8hHJPS547MnFQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/core": "3.677.0",
+        "@aws-sdk/types": "3.667.0",
+        "@aws-sdk/util-arn-parser": "3.568.0",
+        "@smithy/core": "^2.4.8",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/signature-v4": "^4.2.0",
+        "@smithy/smithy-client": "^3.4.0",
+        "@smithy/types": "^3.5.0",
         "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-stream": "^3.1.3",
+        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-stream": "^3.1.9",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -7162,15 +14104,28 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
-      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
       "dev": true,
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7178,12 +14133,25 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7191,13 +14159,26 @@
       }
     },
     "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.609.0.tgz",
-      "integrity": "sha512-GZSD1s7+JswWOTamVap79QiDaIV7byJFssBW68GYjyRS5EBjNfwA/8s+6uE6g39R3ojyTbYOmvcANoZEhSULXg==",
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.667.0.tgz",
+      "integrity": "sha512-1wuAUZIkmZIvOmGg5qNQU821CGFHhkuKioxXgNh0DpUxZ9+AeiV7yorJr+bqkb2KBFv1i1TnzGRecvKf/KvZIQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/types": "3.667.0",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7205,14 +14186,30 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.637.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.637.0.tgz",
-      "integrity": "sha512-EYo0NE9/da/OY8STDsK2LvM4kNa79DBsf4YVtaG4P5pZ615IeFsD8xOHZeuJmUrSMlVQ8ywPRX7WMucUybsKug==",
+      "version": "3.677.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.677.0.tgz",
+      "integrity": "sha512-A3gzUsTsvyv/JCmD0p2fkbiOyp+tpAiAADDwzi+eYeyzH4xzqnrzSkGk5KSb58uUQo27eeBzRXHd46d0u+sMrQ==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.637.0",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/core": "3.677.0",
+        "@aws-sdk/types": "3.667.0",
+        "@aws-sdk/util-endpoints": "3.667.0",
+        "@smithy/core": "^2.4.8",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7220,15 +14217,16 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.614.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
-      "integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
+      "version": "3.664.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.664.0.tgz",
+      "integrity": "sha512-o/B8dg8K+9714RGYPgMxZgAChPe/MTSMkf/eHXTUFHNik5i1HgVKfac22njV2iictGy/6GhpFsKa1OWNYAkcUg==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/types": "3.664.0",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/types": "^3.5.0",
         "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-middleware": "^3.0.7",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7236,13 +14234,14 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
-      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
+      "dev": true,
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7250,11 +14249,12 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
+      "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7262,16 +14262,29 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.635.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.635.0.tgz",
-      "integrity": "sha512-J6QY4/invOkpogCHjSaDON1hF03viPpOnsrzVuCvJMmclS/iG62R4EY0wq1alYll0YmSdmKlpJwHMWwGtqK63Q==",
+      "version": "3.677.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.677.0.tgz",
+      "integrity": "sha512-VJvYwPnyPMBbvKDAO58t90/y2AtdRp4epax6QR0XScZEBuS777gQ3wJb1JyHLeEAEolKj/dd6jV5Iq+/lsZIIQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "3.635.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/signature-v4": "^4.1.0",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/middleware-sdk-s3": "3.677.0",
+        "@aws-sdk/types": "3.667.0",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/signature-v4": "^4.2.0",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7279,29 +14292,44 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.614.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
-      "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.667.0.tgz",
+      "integrity": "sha512-ZecJlG8p6D4UTYlBHwOWX6nknVtw/OBJ3yPXTSajBjhUlj9lE2xvejI8gl4rqkyLXk7z3bki+KR4tATbMaM9yg==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/types": "3.667.0",
+        "@smithy/property-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.8",
+        "@smithy/types": "^3.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sso-oidc": "^3.614.0"
+        "@aws-sdk/client-sso-oidc": "^3.667.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/token-providers/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
+      "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7309,11 +14337,11 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
-      "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
+      "version": "3.664.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.664.0.tgz",
+      "integrity": "sha512-+GtXktvVgpreM2b+NJL9OqZGsOzHwlCUrO8jgQUvH/yA6Kd8QO2YFhQCp0C9sSzTteZJVqGBu8E0CQurxJHPbw==",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7333,13 +14361,27 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.637.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.637.0.tgz",
-      "integrity": "sha512-pAqOKUHeVWHEXXDIp/qoMk/6jyxIb6GGjnK1/f8dKHtKIEs4tKsnnL563gceEvdad53OPXIt86uoevCcCzmBnw==",
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.667.0.tgz",
+      "integrity": "sha512-X22SYDAuQJWnkF1/q17pkX3nGw5XMD9YEUbmt87vUnRq7iyJ3JOpl6UKOBeUBaL838wA5yzdbinmCITJ/VZ1QA==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-endpoints": "^2.0.5",
+        "@aws-sdk/types": "3.667.0",
+        "@smithy/types": "^3.5.0",
+        "@smithy/util-endpoints": "^2.1.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7361,6 +14403,19 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-sdk/util-format-url/node_modules/@aws-sdk/types": {
+      "version": "3.609.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
+      "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws-sdk/util-locate-window": {
       "version": "3.568.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.568.0.tgz",
@@ -7373,24 +14428,40 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
-      "integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
+      "version": "3.675.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.675.0.tgz",
+      "integrity": "sha512-HW4vGfRiX54RLcsYjLuAhcBBJ6lRVEZd7njfGpAwBB9s7BH8t48vrpYbyA5XbbqbTvXfYBnugQCUw9HWjEa1ww==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/types": "3.667.0",
+        "@smithy/types": "^3.5.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
-    "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.614.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
-      "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
+    "node_modules/@aws-sdk/util-user-agent-browser/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.677.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.677.0.tgz",
+      "integrity": "sha512-gFhL0zVY/um0Eu2aWil82pjWaZL4yBmOnjz0+RDz18okFBHaz1Om8o/H+1Vvj+xsnuDYV4ezVMyAaXVtTcYOnw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.677.0",
+        "@aws-sdk/types": "3.667.0",
+        "@smithy/node-config-provider": "^3.1.8",
+        "@smithy/types": "^3.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7405,14 +14476,28 @@
         }
       }
     },
-    "node_modules/@aws-sdk/util-user-agent-node/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
-      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+    "node_modules/@aws-sdk/util-user-agent-node/node_modules/@aws-sdk/types": {
+      "version": "3.667.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.667.0.tgz",
+      "integrity": "sha512-gYq0xCsqFfQaSL/yT1Gl1vIUjtsg7d7RhnUfsXaHt8xTxOKRTdH9GjbesBjXOzgOvB0W0vfssfreSNGFlOOMJg==",
+      "dev": true,
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7420,11 +14505,12 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
+      "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7432,12 +14518,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.609.0.tgz",
-      "integrity": "sha512-l9XxNcA4HX98rwCC2/KoiWcmEiRfZe4G+mYwDbCFT87JIMj6GBhLDkAzr/W8KAaA2IDr8Vc6J8fZPgVulxxfMA==",
+      "version": "3.662.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.662.0.tgz",
+      "integrity": "sha512-ikLkXn0igUpnJu2mCZjklvmcDGWT9OaLRv3JyC/cRkTaaSrblPjPM7KKsltxdMTLQ+v7fjCN0TsJpxphMfaOPA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7445,12 +14531,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
-      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.25.9.tgz",
+      "integrity": "sha512-z88xeGxnzehn2sqZ8UdGQEvYErF1odv2CftxInpSYJt6uHuPe9YjahKZITGs3l5LeI9d2ROG+obuDAoSlqbNfQ==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.24.7",
+        "@babel/highlight": "^7.25.9",
         "picocolors": "^1.0.0"
       },
       "engines": {
@@ -7458,30 +14544,30 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.4.tgz",
-      "integrity": "sha512-+LGRog6RAsCJrrrg/IO6LGmpphNe5DiK30dGjCoxxeGv49B10/3XYGxPsAwrDlMFcFEvdAUavDT8r9k/hSyQqQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.9.tgz",
+      "integrity": "sha512-yD+hEuJ/+wAJ4Ox2/rpNv5HIuPG82x3ZlQvYVn8iYCprdxzE7P1udpGF1jyjQVBU4dgznN+k2h103vxZ7NdPyw==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.2.tgz",
-      "integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.9.tgz",
+      "integrity": "sha512-WYvQviPw+Qyib0v92AwNIrdLISTp7RfDkM7bPqBvpbnhY4wq8HvHBZREVdYDXk98C8BkOIVnHAY3yvj7AVISxQ==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.25.0",
-        "@babel/helper-compilation-targets": "^7.25.2",
-        "@babel/helper-module-transforms": "^7.25.2",
-        "@babel/helpers": "^7.25.0",
-        "@babel/parser": "^7.25.0",
-        "@babel/template": "^7.25.0",
-        "@babel/traverse": "^7.25.2",
-        "@babel/types": "^7.25.2",
+        "@babel/code-frame": "^7.25.9",
+        "@babel/generator": "^7.25.9",
+        "@babel/helper-compilation-targets": "^7.25.9",
+        "@babel/helper-module-transforms": "^7.25.9",
+        "@babel/helpers": "^7.25.9",
+        "@babel/parser": "^7.25.9",
+        "@babel/template": "^7.25.9",
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -7497,32 +14583,43 @@
       }
     },
     "node_modules/@babel/core/node_modules/@babel/generator": {
-      "version": "7.25.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.5.tgz",
-      "integrity": "sha512-abd43wyLfbWoxC6ahM8xTkqLpGB2iWBVyuKC9/srhFunCd1SDNrV1s72bBpK4hLj8KLzHBBcOblvLQZBNw9r3w==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.9.tgz",
+      "integrity": "sha512-omlUGkr5EaoIJrhLf9CJ0TvjBRpd9+AXRG//0GEQ9THSo8wPiTlbpy1/Ow8ZTrbXpjd9FHXfbFQx32I04ht0FA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.25.4",
+        "@babel/types": "^7.25.9",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
-        "jsesc": "^2.5.1"
+        "jsesc": "^3.0.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core/node_modules/@babel/types": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.4.tgz",
-      "integrity": "sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.9.tgz",
+      "integrity": "sha512-OwS2CM5KocvQ/k7dFJa8i5bNGJP0hXWfVCfDkqRFP1IreH1JDC7wG6eCYCi0+McbfT8OR/kNqsI0UU0xP9H6PQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/jsesc": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@babel/core/node_modules/semver": {
@@ -7548,40 +14645,39 @@
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.7.tgz",
-      "integrity": "sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.9.tgz",
+      "integrity": "sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.24.7"
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-annotate-as-pure/node_modules/@babel/types": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.4.tgz",
-      "integrity": "sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.9.tgz",
+      "integrity": "sha512-OwS2CM5KocvQ/k7dFJa8i5bNGJP0hXWfVCfDkqRFP1IreH1JDC7wG6eCYCi0+McbfT8OR/kNqsI0UU0xP9H6PQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.2.tgz",
-      "integrity": "sha512-U2U5LsSaZ7TAt3cfaymQ8WHh0pxvdHoEk6HVpaexxixjyEquMh0L0YNJNM6CTGKMXV1iksi0iZkGw4AcFkPaaw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz",
+      "integrity": "sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.25.2",
-        "@babel/helper-validator-option": "^7.24.8",
-        "browserslist": "^4.23.1",
+        "@babel/compat-data": "^7.25.9",
+        "@babel/helper-validator-option": "^7.25.9",
+        "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
       },
@@ -7599,17 +14695,17 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.4.tgz",
-      "integrity": "sha512-ro/bFs3/84MDgDmMwbcHgDa8/E6J3QKNTk4xJJnVeFtGE+tL0K26E3pNxhYz2b67fJpt7Aphw5XcploKXuCvCQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.9.tgz",
+      "integrity": "sha512-UTZQMvt0d/rSz6KI+qdu7GQze5TIajwTS++GUozlw8VBJDEOAqSXwm1WvmYEZwqdqSGQshRocPDqrt4HBZB3fQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.24.7",
-        "@babel/helper-member-expression-to-functions": "^7.24.8",
-        "@babel/helper-optimise-call-expression": "^7.24.7",
-        "@babel/helper-replace-supers": "^7.25.0",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
-        "@babel/traverse": "^7.25.4",
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "@babel/helper-member-expression-to-functions": "^7.25.9",
+        "@babel/helper-optimise-call-expression": "^7.25.9",
+        "@babel/helper-replace-supers": "^7.25.9",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
+        "@babel/traverse": "^7.25.9",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -7629,69 +14725,67 @@
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.8.tgz",
-      "integrity": "sha512-LABppdt+Lp/RlBxqrh4qgf1oEH/WxdzQNDJIu5gC/W1GyvPVrOBiItmmM8wan2fm4oYqFuFfkXmlGpLQhPY8CA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.9.tgz",
+      "integrity": "sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==",
       "dev": true,
       "dependencies": {
-        "@babel/traverse": "^7.24.8",
-        "@babel/types": "^7.24.8"
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/types": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.4.tgz",
-      "integrity": "sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.9.tgz",
+      "integrity": "sha512-OwS2CM5KocvQ/k7dFJa8i5bNGJP0hXWfVCfDkqRFP1IreH1JDC7wG6eCYCi0+McbfT8OR/kNqsI0UU0xP9H6PQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
-      "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
+      "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
       "dev": true,
       "dependencies": {
-        "@babel/traverse": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports/node_modules/@babel/types": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.4.tgz",
-      "integrity": "sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.9.tgz",
+      "integrity": "sha512-OwS2CM5KocvQ/k7dFJa8i5bNGJP0hXWfVCfDkqRFP1IreH1JDC7wG6eCYCi0+McbfT8OR/kNqsI0UU0xP9H6PQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.2.tgz",
-      "integrity": "sha512-BjyRAbix6j/wv83ftcVJmBt72QtHI56C7JXZoG2xATiLpmoC7dpd8WnkikExHDVPpi/3qCmO6WY1EaXOluiecQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.9.tgz",
+      "integrity": "sha512-TvLZY/F3+GvdRYFZFyxMvnsKi+4oJdgZzU3BoGN9Uc2d9C6zfNwJcKKhjqLAhK8i46mv93jsO74fDh3ih6rpHA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-module-imports": "^7.24.7",
-        "@babel/helper-simple-access": "^7.24.7",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "@babel/traverse": "^7.25.2"
+        "@babel/helper-module-imports": "^7.25.9",
+        "@babel/helper-simple-access": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -7701,49 +14795,48 @@
       }
     },
     "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.24.7.tgz",
-      "integrity": "sha512-jKiTsW2xmWwxT1ixIdfXUZp+P5yURx2suzLZr5Hi64rURpDYdMW0pv+Uf17EYk2Rd428Lx4tLsnjGJzYKDM/6A==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.25.9.tgz",
+      "integrity": "sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.24.7"
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-optimise-call-expression/node_modules/@babel/types": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.4.tgz",
-      "integrity": "sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.9.tgz",
+      "integrity": "sha512-OwS2CM5KocvQ/k7dFJa8i5bNGJP0hXWfVCfDkqRFP1IreH1JDC7wG6eCYCi0+McbfT8OR/kNqsI0UU0xP9H6PQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz",
-      "integrity": "sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.9.tgz",
+      "integrity": "sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.0.tgz",
-      "integrity": "sha512-q688zIvQVYtZu+i2PsdIu/uWGRpfxzr5WESsfpShfZECkO+d2o+WROWezCi/Q6kJ0tfPa5+pUGUlfx2HhrA3Bg==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.9.tgz",
+      "integrity": "sha512-IiDqTOTBQy0sWyeXyGSC5TBJpGFXBkRynjBeXsvbhQFKj2viwJC76Epz35YLU1fpe/Am6Vppb7W7zM4fPQzLsQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.24.8",
-        "@babel/helper-optimise-call-expression": "^7.24.7",
-        "@babel/traverse": "^7.25.0"
+        "@babel/helper-member-expression-to-functions": "^7.25.9",
+        "@babel/helper-optimise-call-expression": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -7753,120 +14846,117 @@
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
-      "integrity": "sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.25.9.tgz",
+      "integrity": "sha512-c6WHXuiaRsJTyHYLJV75t9IqsmTbItYfdj99PnzYGQZkYKvan5/2jKJ7gu31J3/BJ/A18grImSPModuyG/Eo0Q==",
       "dev": true,
       "dependencies": {
-        "@babel/traverse": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-simple-access/node_modules/@babel/types": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.4.tgz",
-      "integrity": "sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.9.tgz",
+      "integrity": "sha512-OwS2CM5KocvQ/k7dFJa8i5bNGJP0hXWfVCfDkqRFP1IreH1JDC7wG6eCYCi0+McbfT8OR/kNqsI0UU0xP9H6PQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.24.7.tgz",
-      "integrity": "sha512-IO+DLT3LQUElMbpzlatRASEyQtfhSE0+m465v++3jyyXeBTBUjtVZg28/gHeV5mrTJqvEKhKroBGAvhW+qPHiQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.25.9.tgz",
+      "integrity": "sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==",
       "dev": true,
       "dependencies": {
-        "@babel/traverse": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/types": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.4.tgz",
-      "integrity": "sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.9.tgz",
+      "integrity": "sha512-OwS2CM5KocvQ/k7dFJa8i5bNGJP0hXWfVCfDkqRFP1IreH1JDC7wG6eCYCi0+McbfT8OR/kNqsI0UU0xP9H6PQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
-      "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
-      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.8.tgz",
-      "integrity": "sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
+      "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.0.tgz",
-      "integrity": "sha512-MjgLZ42aCm0oGjJj8CtSM3DB8NOOf8h2l7DCTePJs29u+v7yO/RBX9nShlKMgFnRks/Q4tBAe7Hxnov9VkGwLw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.9.tgz",
+      "integrity": "sha512-oKWp3+usOJSzDZOucZUAMayhPz/xVjzymyDzUN8dk0Wd3RWMlGLXi07UCQ/CgQVb8LvXx3XBajJH4XGgkt7H7g==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.25.0",
-        "@babel/types": "^7.25.0"
+        "@babel/template": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers/node_modules/@babel/types": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.4.tgz",
-      "integrity": "sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.9.tgz",
+      "integrity": "sha512-OwS2CM5KocvQ/k7dFJa8i5bNGJP0hXWfVCfDkqRFP1IreH1JDC7wG6eCYCi0+McbfT8OR/kNqsI0UU0xP9H6PQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
-      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.25.9.tgz",
+      "integrity": "sha512-llL88JShoCsth8fF8R4SJnIn+WLvR6ccFxu1H3FlMhDontdcmZWf2HgIZ7AIqV3Xcck1idlohrN4EUBQz6klbw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.24.7",
+        "@babel/helper-validator-identifier": "^7.25.9",
         "chalk": "^2.4.2",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
@@ -7947,12 +15037,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.4.tgz",
-      "integrity": "sha512-nq+eWrOgdtu3jG5Os4TQP3x3cLA8hR8TvJNjD8vnPa20WGycimcparWnLK4jJhElTK6SDyuJo1weMKO/5LpmLA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.9.tgz",
+      "integrity": "sha512-aI3jjAAO1fh7vY/pBGsn1i9LDbRP43+asrRlkPuTXW5yHXtd1NgTEMudbBoDDxrf1daEEfPJqR+JBMakzrR4Dg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.25.4"
+        "@babel/types": "^7.25.9"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -7962,14 +15052,13 @@
       }
     },
     "node_modules/@babel/parser/node_modules/@babel/types": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.4.tgz",
-      "integrity": "sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.9.tgz",
+      "integrity": "sha512-OwS2CM5KocvQ/k7dFJa8i5bNGJP0hXWfVCfDkqRFP1IreH1JDC7wG6eCYCi0+McbfT8OR/kNqsI0UU0xP9H6PQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -8025,12 +15114,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-flow": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.24.7.tgz",
-      "integrity": "sha512-9G8GYT/dxn/D1IIKOUBmGX0mnmj46mGH9NnZyJLwtCpgh5f7D2VbuKodb+2s9m1Yavh1s7ASQN8lf0eqrb1LTw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.25.9.tgz",
+      "integrity": "sha512-F3FVgxwamIRS3+kfjNaPARX0DSAiH1exrQUVajXiR34hkdA9eyK+8rJbnu55DQjKL/ayuXqjNr2HDXwBEMEtFQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -8040,12 +15129,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.7.tgz",
-      "integrity": "sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.9.tgz",
+      "integrity": "sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -8067,12 +15156,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-arrow-functions": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.24.7.tgz",
-      "integrity": "sha512-Dt9LQs6iEY++gXUwY03DNFat5C2NbO48jj+j/bSAz6b3HgPs39qcPiYt77fDObIcFwj3/C2ICX9YMwGflUoSHQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.25.9.tgz",
+      "integrity": "sha512-6jmooXYIwn9ca5/RylZADJ+EnSxVUS5sjeJ9UPk6RWRzXCmOJCy6dqItPJFpw2cuCangPK4OYr5uhGKcmrm5Qg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -8082,12 +15171,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.24.7.tgz",
-      "integrity": "sha512-yO7RAz6EsVQDaBH18IDJcMB1HnrUn2FJ/Jslc/WtPPWcjhpUJXU/rjbwmluzp7v/ZzWcEhTMXELnnsz8djWDwQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.25.9.tgz",
+      "integrity": "sha512-toHc9fzab0ZfenFpsyYinOX0J/5dgJVA2fm64xPewu7CoYHWEivIWKxkK2rMi4r3yQqLnVmheMXRdG+k239CgA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -8097,12 +15186,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.25.0.tgz",
-      "integrity": "sha512-yBQjYoOjXlFv9nlXb3f1casSHOZkWr29NX+zChVanLg5Nc157CrbEX9D7hxxtTpuFy7Q0YzmmWfJxzvps4kXrQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.25.9.tgz",
+      "integrity": "sha512-1F05O7AYjymAtqbsFETboN1NvBdcnzMerO+zlMyJBEz6WkMdejvGWw9p05iTSjC85RLlBseHHQpYaM4gzJkBGg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.8"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -8112,16 +15201,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-classes": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.4.tgz",
-      "integrity": "sha512-oexUfaQle2pF/b6E0dwsxQtAol9TLSO88kQvym6HHBWFliV2lGdrPieX+WgMRLSJDVzdYywk7jXbLPuO2KLTLg==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.9.tgz",
+      "integrity": "sha512-mD8APIXmseE7oZvZgGABDyM34GUmK45Um2TXiBUt7PnuAxrgoSVf123qUzPxEr/+/BHrRn5NMZCdE2m/1F8DGg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.24.7",
-        "@babel/helper-compilation-targets": "^7.25.2",
-        "@babel/helper-plugin-utils": "^7.24.8",
-        "@babel/helper-replace-supers": "^7.25.0",
-        "@babel/traverse": "^7.25.4",
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "@babel/helper-compilation-targets": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-replace-supers": "^7.25.9",
+        "@babel/traverse": "^7.25.9",
         "globals": "^11.1.0"
       },
       "engines": {
@@ -8132,13 +15221,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-computed-properties": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.24.7.tgz",
-      "integrity": "sha512-25cS7v+707Gu6Ds2oY6tCkUwsJ9YIDbggd9+cu9jzzDgiNq7hR/8dkzxWfKWnTic26vsI3EsCXNd4iEB6e8esQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.25.9.tgz",
+      "integrity": "sha512-HnBegGqXZR12xbcTHlJ9HGxw1OniltT26J5YpfruGqtUHlz/xKf/G2ak9e+t0rVqrjXa9WOhvYPz1ERfMj23AA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7",
-        "@babel/template": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/template": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -8148,12 +15237,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-destructuring": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.24.8.tgz",
-      "integrity": "sha512-36e87mfY8TnRxc7yc6M9g9gOB7rKgSahqkIKwLpz4Ppk2+zC2Cy1is0uwtuSG6AE4zlTOUa+7JGz9jCJGLqQFQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.25.9.tgz",
+      "integrity": "sha512-WkCGb/3ZxXepmMiX101nnGiU+1CAdut8oHyEOHxkKuS1qKpU2SMXE2uSvfz8PBuLd49V6LEsbtyPhWC7fnkgvQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.8"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -8163,13 +15252,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-flow-strip-types": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.25.2.tgz",
-      "integrity": "sha512-InBZ0O8tew5V0K6cHcQ+wgxlrjOw1W4wDXLkOTjLRD8GYhTSkxTVBtdy3MMtvYBrbAWa1Qm3hNoTc1620Yj+Mg==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.25.9.tgz",
+      "integrity": "sha512-/VVukELzPDdci7UUsWQaSkhgnjIWXnIyRpM02ldxaVoFK96c41So8JcKT3m0gYjyv7j5FNPGS5vfELrWalkbDA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.8",
-        "@babel/plugin-syntax-flow": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/plugin-syntax-flow": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -8179,13 +15268,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-for-of": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.24.7.tgz",
-      "integrity": "sha512-wo9ogrDG1ITTTBsy46oGiN1dS9A7MROBTcYsfS8DtsImMkHk9JXJ3EWQM6X2SUw4x80uGPlwj0o00Uoc6nEE3g==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.25.9.tgz",
+      "integrity": "sha512-LqHxduHoaGELJl2uhImHwRQudhCM50pT46rIBNvtT/Oql3nqiS3wOwP+5ten7NpYSXrrVLgtZU3DZmPtWZo16A==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -8195,14 +15284,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-function-name": {
-      "version": "7.25.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.25.1.tgz",
-      "integrity": "sha512-TVVJVdW9RKMNgJJlLtHsKDTydjZAbwIsn6ySBPQaEAUU5+gVvlJt/9nRmqVbsV/IBanRjzWoaAQKLoamWVOUuA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.25.9.tgz",
+      "integrity": "sha512-8lP+Yxjv14Vc5MuWBpJsoUCd3hD6V9DgBon2FVYL4jJgbnVQ9fTgYmonchzZJOVNgzEgbxp4OwAf6xz6M/14XA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-compilation-targets": "^7.24.8",
-        "@babel/helper-plugin-utils": "^7.24.8",
-        "@babel/traverse": "^7.25.1"
+        "@babel/helper-compilation-targets": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -8212,12 +15301,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-literals": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.25.2.tgz",
-      "integrity": "sha512-HQI+HcTbm9ur3Z2DkO+jgESMAMcYLuN/A7NRw9juzxAezN9AvqvUTnpKP/9kkYANz6u7dFlAyOu44ejuGySlfw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.25.9.tgz",
+      "integrity": "sha512-9N7+2lFziW8W9pBl2TzaNht3+pgMIRP74zizeCSrtnSKVdUl8mAjjOP2OOVQAfZ881P2cNjDj1uAMEdeD50nuQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.8"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -8227,12 +15316,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-member-expression-literals": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.24.7.tgz",
-      "integrity": "sha512-T/hRC1uqrzXMKLQ6UCwMT85S3EvqaBXDGf0FaMf4446Qx9vKwlghvee0+uuZcDUCZU5RuNi4781UQ7R308zzBw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.25.9.tgz",
+      "integrity": "sha512-PYazBVfofCQkkMzh2P6IdIUaCEWni3iYEerAsRWuVd8+jlM1S9S9cz1dF9hIzyoZ8IA3+OwVYIp9v9e+GbgZhA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -8242,14 +15331,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.24.8.tgz",
-      "integrity": "sha512-WHsk9H8XxRs3JXKWFiqtQebdh9b/pTk4EgueygFzYlTKAg0Ud985mSevdNjdXdFBATSKVJGQXP1tv6aGbssLKA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.25.9.tgz",
+      "integrity": "sha512-dwh2Ol1jWwL2MgkCzUSOvfmKElqQcuswAZypBSUsScMXvgdT8Ekq5YA6TtqpTVWH+4903NmboMuH1o9i8Rxlyg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.24.8",
-        "@babel/helper-plugin-utils": "^7.24.8",
-        "@babel/helper-simple-access": "^7.24.7"
+        "@babel/helper-module-transforms": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-simple-access": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -8259,13 +15348,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-object-super": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.24.7.tgz",
-      "integrity": "sha512-A/vVLwN6lBrMFmMDmPPz0jnE6ZGx7Jq7d6sT/Ev4H65RER6pZ+kczlf1DthF5N0qaPHBsI7UXiE8Zy66nmAovg==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.25.9.tgz",
+      "integrity": "sha512-Kj/Gh+Rw2RNLbCK1VAWj2U48yxxqL2x0k10nPtSdRa0O2xnHXalD0s+o1A6a0W43gJ00ANo38jxkQreckOzv5A==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7",
-        "@babel/helper-replace-supers": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-replace-supers": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -8275,12 +15364,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-parameters": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.24.7.tgz",
-      "integrity": "sha512-yGWW5Rr+sQOhK0Ot8hjDJuxU3XLRQGflvT4lhlSY0DFvdb3TwKaY26CJzHtYllU0vT9j58hc37ndFPsqT1SrzA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.25.9.tgz",
+      "integrity": "sha512-wzz6MKwpnshBAiRmn4jR8LYz/g8Ksg0o80XmwZDlordjwEk9SxBzTWC7F5ef1jhbrbOW2DJ5J6ayRukrJmnr0g==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -8290,12 +15379,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-property-literals": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.24.7.tgz",
-      "integrity": "sha512-EMi4MLQSHfd2nrCqQEWxFdha2gBCqU4ZcCng4WBGZ5CJL4bBRW0ptdqqDdeirGZcpALazVVNJqRmsO8/+oNCBA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.25.9.tgz",
+      "integrity": "sha512-IvIUeV5KrS/VPavfSM/Iu+RE6llrHrYIKY1yfCzyO/lMXHQ+p7uGhonmGVisv6tSBSVgWzMBohTcvkC9vQcQFA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -8305,12 +15394,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-display-name": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.24.7.tgz",
-      "integrity": "sha512-H/Snz9PFxKsS1JLI4dJLtnJgCJRoo0AUm3chP6NYr+9En1JMKloheEiLIhlp5MDVznWo+H3AAC1Mc8lmUEpsgg==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.25.9.tgz",
+      "integrity": "sha512-KJfMlYIUxQB1CJfO3e0+h0ZHWOTLCPP115Awhaz8U0Zpq36Gl/cXlpoyMRnUWlhNUBAzldnCiAZNvCDj7CrKxQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -8320,16 +15409,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.2.tgz",
-      "integrity": "sha512-KQsqEAVBpU82NM/B/N9j9WOdphom1SZH3R+2V7INrQUH+V9EBFwZsEJl8eBIVeQE62FxJCc70jzEZwqU7RcVqA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.9.tgz",
+      "integrity": "sha512-s5XwpQYCqGerXl+Pu6VDL3x0j2d82eiV77UJ8a2mDHAW7j9SWRqQ2y1fNo1Z74CdcYipl5Z41zvjj4Nfzq36rw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.24.7",
-        "@babel/helper-module-imports": "^7.24.7",
-        "@babel/helper-plugin-utils": "^7.24.8",
-        "@babel/plugin-syntax-jsx": "^7.24.7",
-        "@babel/types": "^7.25.2"
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "@babel/helper-module-imports": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/plugin-syntax-jsx": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -8339,12 +15428,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-self": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.24.7.tgz",
-      "integrity": "sha512-fOPQYbGSgH0HUp4UJO4sMBFjY6DuWq+2i8rixyUMb3CdGixs/gccURvYOAhajBdKDoGajFr3mUq5rH3phtkGzw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.25.9.tgz",
+      "integrity": "sha512-y8quW6p0WHkEhmErnfe58r7x0A70uKphQm8Sp8cV7tjNQwK56sNVK0M73LK3WuYmsuyrftut4xAkjjgU0twaMg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -8354,12 +15443,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-source": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.24.7.tgz",
-      "integrity": "sha512-J2z+MWzZHVOemyLweMqngXrgGC42jQ//R0KdxqkIz/OrbVIIlhFI3WigZ5fO+nwFvBlncr4MGapd8vTyc7RPNQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.25.9.tgz",
+      "integrity": "sha512-+iqjT8xmXhhYv4/uiYd8FNQsraMFZIfxVSqxxVSZP0WbbSAWvBXAul0m/zu+7Vv4O/3WtApy9pmaTMiumEZgfg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -8369,26 +15458,25 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx/node_modules/@babel/types": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.4.tgz",
-      "integrity": "sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.9.tgz",
+      "integrity": "sha512-OwS2CM5KocvQ/k7dFJa8i5bNGJP0hXWfVCfDkqRFP1IreH1JDC7wG6eCYCi0+McbfT8OR/kNqsI0UU0xP9H6PQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/plugin-transform-shorthand-properties": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.24.7.tgz",
-      "integrity": "sha512-KsDsevZMDsigzbA09+vacnLpmPH4aWjcZjXdyFKGzpplxhbeB4wYtury3vglQkg6KM/xEPKt73eCjPPf1PgXBA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.25.9.tgz",
+      "integrity": "sha512-MUv6t0FhO5qHnS/W8XCbHmiRWOphNufpE1IVxhK5kuN3Td9FT1x4rx4K42s3RYdMXCXpfWkGSbCSd0Z64xA7Ng==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -8398,13 +15486,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-spread": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.24.7.tgz",
-      "integrity": "sha512-x96oO0I09dgMDxJaANcRyD4ellXFLLiWhuwDxKZX5g2rWP1bTPkBSwCYv96VDXVT1bD9aPj8tppr5ITIh8hBng==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.25.9.tgz",
+      "integrity": "sha512-oNknIB0TbURU5pqJFVbOOFspVlrpVwo2H1+HUIsVDvp5VauGGDP1ZEvO8Nn5xyMEs3dakajOxlmkNW7kNgSm6A==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -8414,12 +15502,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-template-literals": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.24.7.tgz",
-      "integrity": "sha512-AfDTQmClklHCOLxtGoP7HkeMw56k1/bTQjwsfhL6pppo/M4TOBSq+jjBUBLmV/4oeFg4GWMavIl44ZeCtmmZTw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.25.9.tgz",
+      "integrity": "sha512-o97AE4syN71M/lxrCtQByzphAdlYluKPDBzDVzMmfCobUjjhAryZV0AIpRPrxN0eAkxXO6ZLEScmt+PNhj2OTw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -8429,9 +15517,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.4.tgz",
-      "integrity": "sha512-DSgLeL/FNcpXuzav5wfYvHCGvynXkJbn3Zvc3823AEe9nPwW9IK4UoCSS5yGymmQzN0pCPvivtgS6/8U2kkm1w==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.9.tgz",
+      "integrity": "sha512-4zpTHZ9Cm6L9L+uIqghQX8ZXg8HKFcjYO3qHoO8zTmRm6HQUJ8SSJ+KRvbMBZn0EGVlT4DRYeQ/6hjlyXBh+Kg==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -8440,44 +15528,43 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
-      "integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
+      "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.24.7",
-        "@babel/parser": "^7.25.0",
-        "@babel/types": "^7.25.0"
+        "@babel/code-frame": "^7.25.9",
+        "@babel/parser": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template/node_modules/@babel/types": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.4.tgz",
-      "integrity": "sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.9.tgz",
+      "integrity": "sha512-OwS2CM5KocvQ/k7dFJa8i5bNGJP0hXWfVCfDkqRFP1IreH1JDC7wG6eCYCi0+McbfT8OR/kNqsI0UU0xP9H6PQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.4.tgz",
-      "integrity": "sha512-VJ4XsrD+nOvlXyLzmLzUs/0qjFS4sK30te5yEFlvbbUNEgKaVb2BHZUpAL+ttLPQAHNrsI3zZisbfha5Cvr8vg==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.9.tgz",
+      "integrity": "sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.25.4",
-        "@babel/parser": "^7.25.4",
-        "@babel/template": "^7.25.0",
-        "@babel/types": "^7.25.4",
+        "@babel/code-frame": "^7.25.9",
+        "@babel/generator": "^7.25.9",
+        "@babel/parser": "^7.25.9",
+        "@babel/template": "^7.25.9",
+        "@babel/types": "^7.25.9",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -8486,32 +15573,43 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/@babel/generator": {
-      "version": "7.25.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.5.tgz",
-      "integrity": "sha512-abd43wyLfbWoxC6ahM8xTkqLpGB2iWBVyuKC9/srhFunCd1SDNrV1s72bBpK4hLj8KLzHBBcOblvLQZBNw9r3w==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.9.tgz",
+      "integrity": "sha512-omlUGkr5EaoIJrhLf9CJ0TvjBRpd9+AXRG//0GEQ9THSo8wPiTlbpy1/Ow8ZTrbXpjd9FHXfbFQx32I04ht0FA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.25.4",
+        "@babel/types": "^7.25.9",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
-        "jsesc": "^2.5.1"
+        "jsesc": "^3.0.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse/node_modules/@babel/types": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.4.tgz",
-      "integrity": "sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.9.tgz",
+      "integrity": "sha512-OwS2CM5KocvQ/k7dFJa8i5bNGJP0hXWfVCfDkqRFP1IreH1JDC7wG6eCYCi0+McbfT8OR/kNqsI0UU0xP9H6PQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/jsesc": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@babel/types": {
@@ -8925,9 +16023,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.0.tgz",
-      "integrity": "sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.1.tgz",
+      "integrity": "sha512-m4DVN9ZqskZoLU5GlWZadwDnYo3vAEydiUayB9widCl9ffWx2IvPnp6n3on5rJmziJSw9Bv+Z3ChDVdMwXCY8Q==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -9006,9 +16104,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
-      "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -9073,9 +16171,9 @@
       }
     },
     "node_modules/@graphql-codegen/core/node_modules/@graphql-tools/utils": {
-      "version": "10.5.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.4.tgz",
-      "integrity": "sha512-XHnyCWSlg1ccsD8s0y6ugo5GZ5TpkTiFVNPSYms5G0s6Z/xTuSmiLBfeqgkfaCwLmLaQnRCmNDL2JRnqc2R5bQ==",
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.5.tgz",
+      "integrity": "sha512-LF/UDWmMT0mnobL2UZETwYghV7HYBzNaGj0SAkCYOMy/C3+6sQdbcTksnoFaKR9XIVD78jNXEGfivbB8Zd+cwA==",
       "dev": true,
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -9362,13 +16460,13 @@
       "dev": true
     },
     "node_modules/@graphql-tools/apollo-engine-loader": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/apollo-engine-loader/-/apollo-engine-loader-8.0.1.tgz",
-      "integrity": "sha512-NaPeVjtrfbPXcl+MLQCJLWtqe2/E4bbAqcauEOQ+3sizw1Fc2CNmhHRF8a6W4D0ekvTRRXAMptXYgA2uConbrA==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/apollo-engine-loader/-/apollo-engine-loader-8.0.2.tgz",
+      "integrity": "sha512-HTFoCILMU7u/Y97G5iu2EPSMTW/b/Lx6Ww2emX/WDtubU2A/7RqzBUjrDj/JMPTEblOAPUwJ1XcxtvXgQVaSyQ==",
       "dev": true,
       "dependencies": {
         "@ardatan/sync-fetch": "^0.0.1",
-        "@graphql-tools/utils": "^10.0.13",
+        "@graphql-tools/utils": "^10.5.5",
         "@whatwg-node/fetch": "^0.9.0",
         "tslib": "^2.4.0"
       },
@@ -9380,9 +16478,9 @@
       }
     },
     "node_modules/@graphql-tools/apollo-engine-loader/node_modules/@graphql-tools/utils": {
-      "version": "10.5.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.4.tgz",
-      "integrity": "sha512-XHnyCWSlg1ccsD8s0y6ugo5GZ5TpkTiFVNPSYms5G0s6Z/xTuSmiLBfeqgkfaCwLmLaQnRCmNDL2JRnqc2R5bQ==",
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.5.tgz",
+      "integrity": "sha512-LF/UDWmMT0mnobL2UZETwYghV7HYBzNaGj0SAkCYOMy/C3+6sQdbcTksnoFaKR9XIVD78jNXEGfivbB8Zd+cwA==",
       "dev": true,
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -9398,12 +16496,12 @@
       }
     },
     "node_modules/@graphql-tools/merge": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.6.tgz",
-      "integrity": "sha512-TmkzFTFVieHnqu9mPTF6RxAQltaprpDQnM5HMTPSyMLXnJGMTvdWejV0yORKj7DW1YSi791/sUnKf8HytepBFQ==",
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.8.tgz",
+      "integrity": "sha512-RG9NEp4fi0MoFi0te4ahqTMYuavQnXlpEZxxMomdCa6CI5tfekcVm/rsLF5Zt8O4HY+esDt9+4dCL+aOKvG79w==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/utils": "^10.5.4",
+        "@graphql-tools/utils": "^10.5.5",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -9414,9 +16512,9 @@
       }
     },
     "node_modules/@graphql-tools/merge/node_modules/@graphql-tools/utils": {
-      "version": "10.5.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.4.tgz",
-      "integrity": "sha512-XHnyCWSlg1ccsD8s0y6ugo5GZ5TpkTiFVNPSYms5G0s6Z/xTuSmiLBfeqgkfaCwLmLaQnRCmNDL2JRnqc2R5bQ==",
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.5.tgz",
+      "integrity": "sha512-LF/UDWmMT0mnobL2UZETwYghV7HYBzNaGj0SAkCYOMy/C3+6sQdbcTksnoFaKR9XIVD78jNXEGfivbB8Zd+cwA==",
       "dev": true,
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -9471,13 +16569,13 @@
       }
     },
     "node_modules/@graphql-tools/schema": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.6.tgz",
-      "integrity": "sha512-EIJgPRGzpvDFEjVp+RF1zNNYIC36BYuIeZ514jFoJnI6IdxyVyIRDLx/ykgMdaa1pKQerpfdqDnsF4JnZoDHSQ==",
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.7.tgz",
+      "integrity": "sha512-Cz1o+rf9cd3uMgG+zI9HlM5mPlnHQUlk/UQRZyUlPDfT+944taLaokjvj7AI6GcOFVf4f2D11XthQp+0GY31jQ==",
       "dev": true,
       "dependencies": {
-        "@graphql-tools/merge": "^9.0.6",
-        "@graphql-tools/utils": "^10.5.4",
+        "@graphql-tools/merge": "^9.0.8",
+        "@graphql-tools/utils": "^10.5.5",
         "tslib": "^2.4.0",
         "value-or-promise": "^1.0.12"
       },
@@ -9489,9 +16587,9 @@
       }
     },
     "node_modules/@graphql-tools/schema/node_modules/@graphql-tools/utils": {
-      "version": "10.5.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.4.tgz",
-      "integrity": "sha512-XHnyCWSlg1ccsD8s0y6ugo5GZ5TpkTiFVNPSYms5G0s6Z/xTuSmiLBfeqgkfaCwLmLaQnRCmNDL2JRnqc2R5bQ==",
+      "version": "10.5.5",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.5.5.tgz",
+      "integrity": "sha512-LF/UDWmMT0mnobL2UZETwYghV7HYBzNaGj0SAkCYOMy/C3+6sQdbcTksnoFaKR9XIVD78jNXEGfivbB8Zd+cwA==",
       "dev": true,
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -9536,13 +16634,13 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.14",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
-      "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
       "deprecated": "Use @eslint/config-array instead",
       "dev": true,
       "dependencies": {
-        "@humanwhocodes/object-schema": "^2.0.2",
+        "@humanwhocodes/object-schema": "^2.0.3",
         "debug": "^4.3.1",
         "minimatch": "^3.0.5"
       },
@@ -9901,9 +16999,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.2.tgz",
-      "integrity": "sha512-w9qFkumYDCNyDZmNQjf/n6qQuvQ4dMC3BJesY4oF+yr0CxR5vxujflAVeIcS6U336uzi9GM0kAfZlLrZ9UTkpA==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.5.tgz",
+      "integrity": "sha512-MzICLu4yS7V8AA61sANROZ9vT1H3ooca5dSmI1FjZkzq7o/koMsRfQSzRtFo+F3Ao4Sf1C0bpLKejpKB/+j6MA==",
       "dev": true,
       "dependencies": {
         "mute-stream": "^1.0.0"
@@ -9930,9 +17028,9 @@
       }
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -10746,9 +17844,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.22.4.tgz",
-      "integrity": "sha512-Fxamp4aEZnfPOcGA8KSNEohV8hX7zVHOemC8jVBoBUHu5zpJK/Eu3uJwt6BMgy9fkvzxDaurgj96F/NiLukF2w==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.24.0.tgz",
+      "integrity": "sha512-Q6HJd7Y6xdB48x8ZNVDOqsbh2uByBhgK8PiQgPhwkIw/HC/YX5Ghq2mQY5sRMZWHb3VsFkWooUVOZHKr7DmDIA==",
       "cpu": [
         "arm"
       ],
@@ -10759,9 +17857,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.22.4.tgz",
-      "integrity": "sha512-VXoK5UMrgECLYaMuGuVTOx5kcuap1Jm8g/M83RnCHBKOqvPPmROFJGQaZhGccnsFtfXQ3XYa4/jMCJvZnbJBdA==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.24.0.tgz",
+      "integrity": "sha512-ijLnS1qFId8xhKjT81uBHuuJp2lU4x2yxa4ctFPtG+MqEE6+C5f/+X/bStmxapgmwLwiL3ih122xv8kVARNAZA==",
       "cpu": [
         "arm64"
       ],
@@ -10772,9 +17870,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.22.4.tgz",
-      "integrity": "sha512-xMM9ORBqu81jyMKCDP+SZDhnX2QEVQzTcC6G18KlTQEzWK8r/oNZtKuZaCcHhnsa6fEeOBionoyl5JsAbE/36Q==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.24.0.tgz",
+      "integrity": "sha512-bIv+X9xeSs1XCk6DVvkO+S/z8/2AMt/2lMqdQbMrmVpgFvXlmde9mLcbQpztXm1tajC3raFDqegsH18HQPMYtA==",
       "cpu": [
         "arm64"
       ],
@@ -10785,9 +17883,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.22.4.tgz",
-      "integrity": "sha512-aJJyYKQwbHuhTUrjWjxEvGnNNBCnmpHDvrb8JFDbeSH3m2XdHcxDd3jthAzvmoI8w/kSjd2y0udT+4okADsZIw==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.24.0.tgz",
+      "integrity": "sha512-X6/nOwoFN7RT2svEQWUsW/5C/fYMBe4fnLK9DQk4SX4mgVBiTA9h64kjUYPvGQ0F/9xwJ5U5UfTbl6BEjaQdBQ==",
       "cpu": [
         "x64"
       ],
@@ -10798,9 +17896,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.22.4.tgz",
-      "integrity": "sha512-j63YtCIRAzbO+gC2L9dWXRh5BFetsv0j0va0Wi9epXDgU/XUi5dJKo4USTttVyK7fGw2nPWK0PbAvyliz50SCQ==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.24.0.tgz",
+      "integrity": "sha512-0KXvIJQMOImLCVCz9uvvdPgfyWo93aHHp8ui3FrtOP57svqrF/roSSR5pjqL2hcMp0ljeGlU4q9o/rQaAQ3AYA==",
       "cpu": [
         "arm"
       ],
@@ -10811,9 +17909,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.22.4.tgz",
-      "integrity": "sha512-dJnWUgwWBX1YBRsuKKMOlXCzh2Wu1mlHzv20TpqEsfdZLb3WoJW2kIEsGwLkroYf24IrPAvOT/ZQ2OYMV6vlrg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.24.0.tgz",
+      "integrity": "sha512-it2BW6kKFVh8xk/BnHfakEeoLPv8STIISekpoF+nBgWM4d55CZKc7T4Dx1pEbTnYm/xEKMgy1MNtYuoA8RFIWw==",
       "cpu": [
         "arm"
       ],
@@ -10824,9 +17922,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.22.4.tgz",
-      "integrity": "sha512-AdPRoNi3NKVLolCN/Sp4F4N1d98c4SBnHMKoLuiG6RXgoZ4sllseuGioszumnPGmPM2O7qaAX/IJdeDU8f26Aw==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.24.0.tgz",
+      "integrity": "sha512-i0xTLXjqap2eRfulFVlSnM5dEbTVque/3Pi4g2y7cxrs7+a9De42z4XxKLYJ7+OhE3IgxvfQM7vQc43bwTgPwA==",
       "cpu": [
         "arm64"
       ],
@@ -10837,9 +17935,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.22.4.tgz",
-      "integrity": "sha512-Gl0AxBtDg8uoAn5CCqQDMqAx22Wx22pjDOjBdmG0VIWX3qUBHzYmOKh8KXHL4UpogfJ14G4wk16EQogF+v8hmA==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.24.0.tgz",
+      "integrity": "sha512-9E6MKUJhDuDh604Qco5yP/3qn3y7SLXYuiC0Rpr89aMScS2UAmK1wHP2b7KAa1nSjWJc/f/Lc0Wl1L47qjiyQw==",
       "cpu": [
         "arm64"
       ],
@@ -10850,9 +17948,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.22.4.tgz",
-      "integrity": "sha512-3aVCK9xfWW1oGQpTsYJJPF6bfpWfhbRnhdlyhak2ZiyFLDaayz0EP5j9V1RVLAAxlmWKTDfS9wyRyY3hvhPoOg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.24.0.tgz",
+      "integrity": "sha512-2XFFPJ2XMEiF5Zi2EBf4h73oR1V/lycirxZxHZNc93SqDN/IWhYYSYj8I9381ikUFXZrz2v7r2tOVk2NBwxrWw==",
       "cpu": [
         "ppc64"
       ],
@@ -10863,9 +17961,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.22.4.tgz",
-      "integrity": "sha512-ePYIir6VYnhgv2C5Xe9u+ico4t8sZWXschR6fMgoPUK31yQu7hTEJb7bCqivHECwIClJfKgE7zYsh1qTP3WHUA==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.24.0.tgz",
+      "integrity": "sha512-M3Dg4hlwuntUCdzU7KjYqbbd+BLq3JMAOhCKdBE3TcMGMZbKkDdJ5ivNdehOssMCIokNHFOsv7DO4rlEOfyKpg==",
       "cpu": [
         "riscv64"
       ],
@@ -10876,9 +17974,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.22.4.tgz",
-      "integrity": "sha512-GqFJ9wLlbB9daxhVlrTe61vJtEY99/xB3C8e4ULVsVfflcpmR6c8UZXjtkMA6FhNONhj2eA5Tk9uAVw5orEs4Q==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.24.0.tgz",
+      "integrity": "sha512-mjBaoo4ocxJppTorZVKWFpy1bfFj9FeCMJqzlMQGjpNPY9JwQi7OuS1axzNIk0nMX6jSgy6ZURDZ2w0QW6D56g==",
       "cpu": [
         "s390x"
       ],
@@ -10889,9 +17987,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.22.4.tgz",
-      "integrity": "sha512-87v0ol2sH9GE3cLQLNEy0K/R0pz1nvg76o8M5nhMR0+Q+BBGLnb35P0fVz4CQxHYXaAOhE8HhlkaZfsdUOlHwg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.24.0.tgz",
+      "integrity": "sha512-ZXFk7M72R0YYFN5q13niV0B7G8/5dcQ9JDp8keJSfr3GoZeXEoMHP/HlvqROA3OMbMdfr19IjCeNAnPUG93b6A==",
       "cpu": [
         "x64"
       ],
@@ -10902,9 +18000,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.22.4.tgz",
-      "integrity": "sha512-UV6FZMUgePDZrFjrNGIWzDo/vABebuXBhJEqrHxrGiU6HikPy0Z3LfdtciIttEUQfuDdCn8fqh7wiFJjCNwO+g==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.24.0.tgz",
+      "integrity": "sha512-w1i+L7kAXZNdYl+vFvzSZy8Y1arS7vMgIy8wusXJzRrPyof5LAb02KGr1PD2EkRcl73kHulIID0M501lN+vobQ==",
       "cpu": [
         "x64"
       ],
@@ -10915,9 +18013,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.22.4.tgz",
-      "integrity": "sha512-BjI+NVVEGAXjGWYHz/vv0pBqfGoUH0IGZ0cICTn7kB9PyjrATSkX+8WkguNjWoj2qSr1im/+tTGRaY+4/PdcQw==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.24.0.tgz",
+      "integrity": "sha512-VXBrnPWgBpVDCVY6XF3LEW0pOU51KbaHhccHw6AS6vBWIC60eqsH19DAeeObl+g8nKAz04QFdl/Cefta0xQtUQ==",
       "cpu": [
         "arm64"
       ],
@@ -10928,9 +18026,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.22.4.tgz",
-      "integrity": "sha512-SiWG/1TuUdPvYmzmYnmd3IEifzR61Tragkbx9D3+R8mzQqDBz8v+BvZNDlkiTtI9T15KYZhP0ehn3Dld4n9J5g==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.24.0.tgz",
+      "integrity": "sha512-xrNcGDU0OxVcPTH/8n/ShH4UevZxKIO6HJFK0e15XItZP2UcaiLFd5kiX7hJnqCbSztUF8Qot+JWBC/QXRPYWQ==",
       "cpu": [
         "ia32"
       ],
@@ -10941,9 +18039,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.22.4.tgz",
-      "integrity": "sha512-j8pPKp53/lq9lMXN57S8cFz0MynJk8OWNuUnXct/9KCpKU7DgU3bYMJhwWmcqC0UU29p8Lr0/7KEVcaM6bf47Q==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.24.0.tgz",
+      "integrity": "sha512-fbMkAF7fufku0N2dE5TBXcNlg0pt0cJue4xBRE2Qc5Vqikxr4VCgKj/ht6SMdFcOacVA9rqF70APJ8RN/4vMJw==",
       "cpu": [
         "x64"
       ],
@@ -10954,11 +18052,11 @@
       ]
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
-      "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.6.tgz",
+      "integrity": "sha512-0XuhuHQlEqbNQZp7QxxrFTdVWdwxch4vjxYgfInF91hZFkPxf9QDrdQka0KfxFMPqLNzSw0b95uGTrLliQUavQ==",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10966,18 +18064,18 @@
       }
     },
     "node_modules/@smithy/chunked-blob-reader": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-3.0.0.tgz",
-      "integrity": "sha512-sbnURCwjF0gSToGlsBiAmd1lRCmSn72nu9axfJu5lIx6RUEgHu6GwTMbqCdhQSi0Pumcm5vFxsi9XWXb2mTaoA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-4.0.0.tgz",
+      "integrity": "sha512-jSqRnZvkT4egkq/7b6/QRCNXmmYVcHwnJldqJ3IhVpQE2atObVJ137xmGeuGFhjFUr8gCEVAOKwSY79OvpbDaQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/chunked-blob-reader-native": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-3.0.0.tgz",
-      "integrity": "sha512-VDkpCYW+peSuM4zJip5WDfqvg2Mo/e8yxOv3VF1m11y7B8KKMKVFtmZWDe36Fvk8rGuWrPZHHXZ7rR7uM5yWyg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-3.0.1.tgz",
+      "integrity": "sha512-VEYtPvh5rs/xlyqpm5NRnfYLZn+q0SRPELbvBV+C/G7IQ+ouTuo+NKKa3ShG5OaFR8NYVMXls9hPYLTvIKKDrQ==",
       "dev": true,
       "dependencies": {
         "@smithy/util-base64": "^3.0.0",
@@ -10985,14 +18083,14 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.5.tgz",
-      "integrity": "sha512-SkW5LxfkSI1bUC74OtfBbdz+grQXYiPYolyu8VfpLIjEoN/sHVBlLeGXMQ1vX4ejkgfv6sxVbQJ32yF2cl1veA==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.10.tgz",
+      "integrity": "sha512-Uh0Sz9gdUuz538nvkPiyv1DZRX9+D15EKDtnQP5rYVAzM/dnYk3P8cg73jcxyOitPgT3mE3OVj7ky7sibzHWkw==",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-middleware": "^3.0.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11000,13 +18098,13 @@
       }
     },
     "node_modules/@smithy/config-resolver/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
-      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11014,11 +18112,11 @@
       }
     },
     "node_modules/@smithy/config-resolver/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11026,18 +18124,16 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.4.0.tgz",
-      "integrity": "sha512-cHXq+FneIF/KJbt4q4pjN186+Jf4ZB0ZOqEaZMBhT79srEyGDDBV31NqBRBjazz8ppQ1bJbDJMY9ba5wKFV36w==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.5.1.tgz",
+      "integrity": "sha512-DujtuDA7BGEKExJ05W5OdxCoyekcKT3Rhg1ZGeiUWaz2BJIWXjZmsG/DIP4W48GHno7AQwRsaCb8NcBgH3QZpg==",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^3.1.0",
-        "@smithy/middleware-retry": "^3.0.15",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/smithy-client": "^3.2.0",
-        "@smithy/types": "^3.3.0",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
         "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-stream": "^3.2.1",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -11045,15 +18141,27 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/credential-provider-imds": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.0.tgz",
-      "integrity": "sha512-0SCIzgd8LYZ9EJxUjLXBmEKSZR/P/w6l7Rz/pab9culE/RWuqelAKGJvn5qUOl8BgX8Yj5HWM50A5hiB/RzsgA==",
+    "node_modules/@smithy/core/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.5.tgz",
+      "integrity": "sha512-4FTQGAsuwqTzVMmiRVTn0RR9GrbRfkP0wfu/tXWVHd2LgNpTY0uglQpIScXK4NaEyXbB3JmZt8gfVqO50lP8wg==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11061,13 +18169,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
-      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11075,11 +18183,11 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11087,23 +18195,34 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-3.1.2.tgz",
-      "integrity": "sha512-0mBcu49JWt4MXhrhRAlxASNy0IjDRFU+aWNDRal9OtUJvJNiwDuyKMUONSOjLjSCeGwZaE0wOErdqULer8r7yw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-3.1.7.tgz",
+      "integrity": "sha512-kVSXScIiRN7q+s1x7BrQtZ1Aa9hvvP9FeCqCdBxv37GimIHgBCOnZ5Ip80HLt0DhnAKpiobFdGqTFgbaJNrazA==",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
         "@smithy/util-hex-encoding": "^3.0.0",
         "tslib": "^2.6.2"
       }
     },
-    "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.6.tgz",
-      "integrity": "sha512-2hM54UWQUOrki4BtsUI1WzmD13/SeaqT/AB3EUJKbcver/WgKNaiJ5y5F5XXuVe6UekffVzuUDrBZVAA3AWRpQ==",
+    "node_modules/@smithy/eventstream-codec/node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^3.0.5",
-        "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.11.tgz",
+      "integrity": "sha512-Pd1Wnq3CQ/v2SxRifDUihvpXzirJYbbtXfEnnLV/z0OGCTx/btVX74P86IgrZkjOydOASBGXdPpupYQI+iO/6A==",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^3.0.10",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11111,11 +18230,11 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.0.3.tgz",
-      "integrity": "sha512-NVTYjOuYpGfrN/VbRQgn31x73KDLfCXCsFdad8DiIc3IcdxL+dYA9zEQPyOP7Fy2QL8CPy2WE4WCUD+ZsLNfaQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.0.8.tgz",
+      "integrity": "sha512-zkFIG2i1BLbfoGQnf1qEeMqX0h5qAznzaZmMVNnvPZz9J5AWBPkOMckZWPedGUPcVITacwIdQXoPcdIQq5FRcg==",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11123,12 +18242,12 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-node": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.5.tgz",
-      "integrity": "sha512-+upXvnHNyZP095s11jF5dhGw/Ihzqwl5G+/KtMnoQOpdfC3B5HYCcDVG9EmgkhJMXJlM64PyN5gjJl0uXFQehQ==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.10.tgz",
+      "integrity": "sha512-hjpU1tIsJ9qpcoZq9zGHBJPBOeBGYt+n8vfhDwnITPhEre6APrvqq/y3XMDEGUT2cWQ4ramNqBPRbx3qn55rhw==",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^3.0.5",
-        "@smithy/types": "^3.3.0",
+        "@smithy/eventstream-serde-universal": "^3.0.10",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11136,12 +18255,12 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.5.tgz",
-      "integrity": "sha512-5u/nXbyoh1s4QxrvNre9V6vfyoLWuiVvvd5TlZjGThIikc3G+uNiG9uOTCWweSRjv1asdDIWK7nOmN7le4RYHQ==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.10.tgz",
+      "integrity": "sha512-ewG1GHbbqsFZ4asaq40KmxCmXO+AFSM1b+DcO2C03dyJj/ZH71CiTg853FSE/3SHK9q3jiYQIFjlGSwfxQ9kww==",
       "dependencies": {
-        "@smithy/eventstream-codec": "^3.1.2",
-        "@smithy/types": "^3.3.0",
+        "@smithy/eventstream-codec": "^3.1.7",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11149,35 +18268,35 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
-      "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.9.tgz",
+      "integrity": "sha512-hYNVQOqhFQ6vOpenifFME546f0GfJn2OiQ3M0FDmuUu8V/Uiwy2wej7ZXxFBNqdx0R5DZAqWM1l6VRhGz8oE6A==",
       "dependencies": {
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/querystring-builder": "^3.0.3",
-        "@smithy/types": "^3.3.0",
+        "@smithy/protocol-http": "^4.1.4",
+        "@smithy/querystring-builder": "^3.0.7",
+        "@smithy/types": "^3.5.0",
         "@smithy/util-base64": "^3.0.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/hash-blob-browser": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-3.1.2.tgz",
-      "integrity": "sha512-hAbfqN2UbISltakCC2TP0kx4LqXBttEv2MqSPE98gVuDFMf05lU+TpC41QtqGP3Ff5A3GwZMPfKnEy0VmEUpmg==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-3.1.7.tgz",
+      "integrity": "sha512-4yNlxVNJifPM5ThaA5HKnHkn7JhctFUHvcaz6YXxHlYOSIrzI6VKQPTN8Gs1iN5nqq9iFcwIR9THqchUCouIfg==",
       "dev": true,
       "dependencies": {
-        "@smithy/chunked-blob-reader": "^3.0.0",
-        "@smithy/chunked-blob-reader-native": "^3.0.0",
-        "@smithy/types": "^3.3.0",
+        "@smithy/chunked-blob-reader": "^4.0.0",
+        "@smithy/chunked-blob-reader-native": "^3.0.1",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
-      "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.8.tgz",
+      "integrity": "sha512-tlNQYbfpWXHimHqrvgo14DrMAgUBua/cNoz9fMYcDmYej7MAmUcjav/QKQbFc3NrcPxeJ7QClER4tWZmfwoPng==",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
         "@smithy/util-buffer-from": "^3.0.0",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
@@ -11186,13 +18305,25 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@smithy/hash-node/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@smithy/hash-stream-node": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-3.1.2.tgz",
-      "integrity": "sha512-PBgDMeEdDzi6JxKwbfBtwQG9eT9cVwsf0dZzLXoJF4sHKHs5HEo/3lJWpn6jibfJwT34I1EBXpBnZE8AxAft6g==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-3.1.7.tgz",
+      "integrity": "sha512-xMAsvJ3hLG63lsBVi1Hl6BBSfhd8/Qnp8fC06kjOpJvyyCEXdwHITa5Kvdsk6gaAXLhbZMhQMIGvgUbfnJDP6Q==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -11200,12 +18331,25 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/invalid-dependency": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
-      "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
+    "node_modules/@smithy/hash-stream-node/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.8.tgz",
+      "integrity": "sha512-7Qynk6NWtTQhnGTTZwks++nJhQ1O54Mzi7fz4PqZOiYXb4Z1Flpb2yRvdALoggTS8xjtohWUM+RygOtB30YL3Q==",
+      "dependencies": {
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       }
     },
@@ -11221,23 +18365,36 @@
       }
     },
     "node_modules/@smithy/md5-js": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-3.0.3.tgz",
-      "integrity": "sha512-O/SAkGVwpWmelpj/8yDtsaVe6sINHLB1q8YE/+ZQbDxIw3SRLbTZuRaI10K12sVoENdnHqzPp5i3/H+BcZ3m3Q==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-3.0.8.tgz",
+      "integrity": "sha512-LwApfTK0OJ/tCyNUXqnWCKoE2b4rDSr4BJlDAVCkiWYeHESr+y+d5zlAanuLW6fnitVJRD/7d9/kN/ZM9Su4mA==",
       "dev": true,
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       }
     },
-    "node_modules/@smithy/middleware-content-length": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.5.tgz",
-      "integrity": "sha512-ILEzC2eyxx6ncej3zZSwMpB5RJ0zuqH7eMptxC4KN3f+v9bqT8ohssKbhNR78k/2tWW+KS5Spw+tbPF4Ejyqvw==",
+    "node_modules/@smithy/md5-js/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dev": true,
       "dependencies": {
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/types": "^3.3.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.10.tgz",
+      "integrity": "sha512-T4dIdCs1d/+/qMpwhJ1DzOhxCZjZHbHazEPJWdB4GDi2HjIZllVzeBEcdJUN0fomV8DURsgOyrbEUzg3vzTaOg==",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11245,16 +18402,17 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
-      "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.2.1.tgz",
+      "integrity": "sha512-wWO3xYmFm6WRW8VsEJ5oU6h7aosFXfszlz3Dj176pTij6o21oZnzkCLzShfmRaaCHDkBXWBdO0c4sQAvLFP6zA==",
       "dependencies": {
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
-        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/core": "^2.5.1",
+        "@smithy/middleware-serde": "^3.0.8",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
+        "@smithy/url-parser": "^3.0.8",
+        "@smithy/util-middleware": "^3.0.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11262,13 +18420,13 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
-      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11276,11 +18434,11 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11288,17 +18446,17 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "3.0.15",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.15.tgz",
-      "integrity": "sha512-iTMedvNt1ApdvkaoE8aSDuwaoc+BhvHqttbA/FO4Ty+y/S5hW6Ci/CTScG7vam4RYJWZxdTElc3MEfHRVH6cgQ==",
+      "version": "3.0.25",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.25.tgz",
+      "integrity": "sha512-m1F70cPaMBML4HiTgCw5I+jFNtjgz5z5UdGnUbG37vw6kh4UvizFYjqJGHvicfgKMkDL6mXwyPp5mhZg02g5sg==",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/smithy-client": "^3.2.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/service-error-classification": "^3.0.8",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-middleware": "^3.0.8",
+        "@smithy/util-retry": "^3.0.8",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
       },
@@ -11307,13 +18465,13 @@
       }
     },
     "node_modules/@smithy/middleware-retry/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
-      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11321,11 +18479,11 @@
       }
     },
     "node_modules/@smithy/middleware-retry/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11333,11 +18491,11 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
-      "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.8.tgz",
+      "integrity": "sha512-Xg2jK9Wc/1g/MBMP/EUn2DLspN8LNt+GMe7cgF+Ty3vl+Zvu+VeZU5nmhveU+H8pxyTsjrAkci8NqY6OuvZnjA==",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11345,11 +18503,11 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
-      "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.8.tgz",
+      "integrity": "sha512-d7ZuwvYgp1+3682Nx0MD3D/HtkmZd49N3JUndYWQXfRZrYEnCWYc8BHcNmVsPAp9gKvlurdg/mubE6b/rPS9MA==",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11397,14 +18555,14 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
-      "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.2.5.tgz",
+      "integrity": "sha512-PkOwPNeKdvX/jCpn0A8n9/TyoxjGZB8WVoJmm9YzsnAgggTj4CrjpRHlTQw7dlLZ320n1mY1y+nTRUDViKi/3w==",
       "dependencies": {
-        "@smithy/abort-controller": "^3.1.1",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/querystring-builder": "^3.0.3",
-        "@smithy/types": "^3.3.0",
+        "@smithy/abort-controller": "^3.1.6",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/querystring-builder": "^3.0.8",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11412,11 +18570,11 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
-      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.8.tgz",
+      "integrity": "sha512-ukNUyo6rHmusG64lmkjFeXemwYuKge1BJ8CtpVKmrxQxc6rhUX0vebcptFA9MmrGsnLhwnnqeH83VTU9hwOpjA==",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11424,11 +18582,11 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
-      "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.5.tgz",
+      "integrity": "sha512-hsjtwpIemmCkm3ZV5fd/T0bPIugW1gJXwZ/hpuVubt2hEUApIoUTrf6qIdh9MAWlw0vjMrA1ztJLAwtNaZogvg==",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11436,11 +18594,11 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
-      "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.8.tgz",
+      "integrity": "sha512-btYxGVqFUARbUrN6VhL9c3dnSviIwBYD9Rz1jHuN1hgh28Fpv2xjU1HeCeDJX68xctz7r4l1PBnFhGg1WBBPuA==",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
         "@smithy/util-uri-escape": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -11449,11 +18607,11 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
-      "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.8.tgz",
+      "integrity": "sha512-BtEk3FG7Ks64GAbt+JnKqwuobJNX8VmFLBsKIwWr1D60T426fGrV2L3YS5siOcUhhp6/Y6yhBw1PSPxA5p7qGg==",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11461,11 +18619,11 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.8.tgz",
+      "integrity": "sha512-uEC/kCCFto83bz5ZzapcrgGqHOh/0r69sZ2ZuHlgoD5kYgXJEThCoTuw/y1Ub3cE7aaKdznb+jD9xRPIfIwD7g==",
       "dependencies": {
-        "@smithy/types": "^3.3.0"
+        "@smithy/types": "^3.6.0"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -11497,15 +18655,15 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.0.tgz",
-      "integrity": "sha512-aRryp2XNZeRcOtuJoxjydO6QTaVhxx/vjaR+gx7ZjaFgrgPRyZ3HCTbfwqYj6ZWEBHkCSUfcaymKPURaByukag==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.1.tgz",
+      "integrity": "sha512-NsV1jF4EvmO5wqmaSzlnTVetemBS3FZHdyc5CExbDljcyJCEEkJr8ANu2JvtNbVg/9MvKAWV44kTrGS+Pi4INg==",
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/types": "^3.3.0",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
         "@smithy/util-hex-encoding": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-middleware": "^3.0.8",
         "@smithy/util-uri-escape": "^3.0.0",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
@@ -11514,16 +18672,40 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/smithy-client": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.2.0.tgz",
-      "integrity": "sha512-pDbtxs8WOhJLJSeaF/eAbPgXg4VVYFlRcL/zoNYA5WbG3wBL06CHtBSg53ppkttDpAJ/hdiede+xApip1CwSLw==",
+    "node_modules/@smithy/signature-v4/node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^3.1.0",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-stream": "^3.1.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.4.2.tgz",
+      "integrity": "sha512-dxw1BDxJiY9/zI3cBqfVrInij6ShjpV4fmGHesGZZUiP9OSE/EVfdwdRz0PgvkEvrZHpsj2htRaHJfftE8giBA==",
+      "dependencies": {
+        "@smithy/core": "^2.5.1",
+        "@smithy/middleware-endpoint": "^3.2.1",
+        "@smithy/middleware-stack": "^3.0.8",
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-stream": "^3.2.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11531,9 +18713,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.6.0.tgz",
+      "integrity": "sha512-8VXK/KzOHefoC65yRgCn5vG1cysPJjHnOVt9d0ybFQSmJgQj152vMn4EkYhGuaOmnnZvCPav/KnYyE6/KsNZ2w==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -11542,12 +18724,12 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
-      "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.8.tgz",
+      "integrity": "sha512-4FdOhwpTW7jtSFWm7SpfLGKIBC9ZaTKG5nBF0wK24aoQKQyDIKUw3+KFWCQ9maMzrgTJIuOvOnsV2lLGW5XjTg==",
       "dependencies": {
-        "@smithy/querystring-parser": "^3.0.3",
-        "@smithy/types": "^3.3.0",
+        "@smithy/querystring-parser": "^3.0.8",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       }
     },
@@ -11558,6 +18740,18 @@
       "dependencies": {
         "@smithy/util-buffer-from": "^3.0.0",
         "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11607,13 +18801,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "3.0.15",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.15.tgz",
-      "integrity": "sha512-FZ4Psa3vjp8kOXcd3HJOiDPBCWtiilLl57r0cnNtq/Ga9RSDrM5ERL6xt+tO43+2af6Pn5Yp92x2n5vPuduNfg==",
+      "version": "3.0.25",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.25.tgz",
+      "integrity": "sha512-fRw7zymjIDt6XxIsLwfJfYUfbGoO9CmCJk6rjJ/X5cd20+d2Is7xjU5Kt/AiDt6hX8DAf5dztmfP5O82gR9emA==",
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/smithy-client": "^3.2.0",
-        "@smithy/types": "^3.3.0",
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -11622,16 +18816,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "3.0.15",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.15.tgz",
-      "integrity": "sha512-KSyAAx2q6d0t6f/S4XB2+3+6aQacm3aLMhs9aLMqn18uYGUepbdssfogW5JQZpc6lXNBnp0tEnR5e9CEKmEd7A==",
+      "version": "3.0.25",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.25.tgz",
+      "integrity": "sha512-H3BSZdBDiVZGzt8TG51Pd2FvFO0PAx/A0mJ0EH8a13KJ6iUCdYnw/Dk/MdC1kTd0eUuUGisDFaxXVXo4HHFL1g==",
       "dependencies": {
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/credential-provider-imds": "^3.2.0",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/smithy-client": "^3.2.0",
-        "@smithy/types": "^3.3.0",
+        "@smithy/config-resolver": "^3.0.10",
+        "@smithy/credential-provider-imds": "^3.2.5",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/smithy-client": "^3.4.2",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11639,13 +18833,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
-      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11653,11 +18847,11 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11665,12 +18859,12 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.5.tgz",
-      "integrity": "sha512-ReQP0BWihIE68OAblC/WQmDD40Gx+QY1Ez8mTdFMXpmjfxSyz2fVQu3A4zXRfQU9sZXtewk3GmhfOHswvX+eNg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.4.tgz",
+      "integrity": "sha512-kPt8j4emm7rdMWQyL0F89o92q10gvCUa6sBkBtDJ7nV2+P7wpXczzOfoDJ49CKXe5CCqb8dc1W+ZdLlrKzSAnQ==",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/node-config-provider": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11678,13 +18872,13 @@
       }
     },
     "node_modules/@smithy/util-endpoints/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
-      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.9.tgz",
+      "integrity": "sha512-qRHoah49QJ71eemjuS/WhUXB+mpNtwHRWQr77J/m40ewBVVwvo52kYAmb7iuaECgGTTcYxHS4Wmewfwy++ueew==",
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/property-provider": "^3.1.8",
+        "@smithy/shared-ini-file-loader": "^3.1.9",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11692,11 +18886,11 @@
       }
     },
     "node_modules/@smithy/util-endpoints/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.9.tgz",
+      "integrity": "sha512-/+OsJRNtoRbtsX0UpSgWVxFZLsJHo/4sTr+kBg/J78sr7iC+tHeOvOJrS5hCpVQ6sWBbhWLp1UNiuMyZhE6pmA==",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11704,6 +18898,72 @@
       }
     },
     "node_modules/@smithy/util-hex-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
+      "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.8.tgz",
+      "integrity": "sha512-p7iYAPaQjoeM+AKABpYWeDdtwQNxasr4aXQEA/OmbOaug9V0odRVDy3Wx4ci8soljE/JXQo+abV0qZpW8NX0yA==",
+      "dependencies": {
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.8.tgz",
+      "integrity": "sha512-TCEhLnY581YJ+g1x0hapPz13JFqzmh/pMWL2KEFASC51qCfw3+Y47MrTmea4bUE5vsdxQ4F6/KFbUeSz22Q1ow==",
+      "dependencies": {
+        "@smithy/service-error-classification": "^3.0.8",
+        "@smithy/types": "^3.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.2.1.tgz",
+      "integrity": "sha512-R3ufuzJRxSJbE58K9AEnL/uSZyVdHzud9wLS8tIbXclxKzoe09CRohj2xV8wpx5tj7ZbiJaKYcutMm1eYgz/0A==",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^4.0.0",
+        "@smithy/node-http-handler": "^3.2.5",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream/node_modules/@smithy/fetch-http-handler": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.0.0.tgz",
+      "integrity": "sha512-MLb1f5tbBO2X6K4lMEKJvxeLooyg7guq48C2zKr4qM7F2Gpkz4dc+hdSgu77pCJ76jVqFBjZczHYAs6dp15N+g==",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.5",
+        "@smithy/querystring-builder": "^3.0.8",
+        "@smithy/types": "^3.6.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/util-stream/node_modules/@smithy/util-hex-encoding": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
       "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
@@ -11714,43 +18974,12 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/util-middleware": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
-      "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+    "node_modules/@smithy/util-stream/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@smithy/util-retry": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-      "dependencies": {
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@smithy/util-stream": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
-      "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
-      "dependencies": {
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-base64": "^3.0.0",
         "@smithy/util-buffer-from": "^3.0.0",
-        "@smithy/util-hex-encoding": "^3.0.0",
-        "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11769,24 +18998,47 @@
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
       "dependencies": {
-        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-buffer-from": "^2.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.1.2.tgz",
-      "integrity": "sha512-4pP0EV3iTsexDx+8PPGAKCQpd/6hsQBaQhqWzU4hqKPHN5epPsxKbvUTIiYIHTxaKt6/kEaqPBpu/ufvfbrRzw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.1.7.tgz",
+      "integrity": "sha512-d5yGlQtmN/z5eoTtIYgkvOw27US2Ous4VycnXatyoImIF9tzlcpnKqQ/V7qhvJmb2p6xZne1NopCLakdTnkBBQ==",
       "dependencies": {
-        "@smithy/abort-controller": "^3.1.1",
-        "@smithy/types": "^3.3.0",
+        "@smithy/abort-controller": "^3.1.6",
+        "@smithy/types": "^3.6.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11794,9 +19046,9 @@
       }
     },
     "node_modules/@types/aws-lambda": {
-      "version": "8.10.143",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.143.tgz",
-      "integrity": "sha512-u5vzlcR14ge/4pMTTMDQr3MF0wEe38B2F9o84uC4F43vN5DGTy63npRrB6jQhyt+C0lGv4ZfiRcRkqJoZuPnmg=="
+      "version": "8.10.145",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.145.tgz",
+      "integrity": "sha512-dtByW6WiFk5W5Jfgz1VM+YPA21xMXTuSFoLYIDY0L44jDLLflVPtZkYuu3/YxpGcvjzKFBZLU+GyKjR0HOYtyw=="
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -11812,14 +19064,13 @@
       }
     },
     "node_modules/@types/babel__core/node_modules/@babel/types": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.4.tgz",
-      "integrity": "sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.9.tgz",
+      "integrity": "sha512-OwS2CM5KocvQ/k7dFJa8i5bNGJP0hXWfVCfDkqRFP1IreH1JDC7wG6eCYCi0+McbfT8OR/kNqsI0UU0xP9H6PQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -11835,14 +19086,13 @@
       }
     },
     "node_modules/@types/babel__generator/node_modules/@babel/types": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.4.tgz",
-      "integrity": "sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.9.tgz",
+      "integrity": "sha512-OwS2CM5KocvQ/k7dFJa8i5bNGJP0hXWfVCfDkqRFP1IreH1JDC7wG6eCYCi0+McbfT8OR/kNqsI0UU0xP9H6PQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -11859,14 +19109,13 @@
       }
     },
     "node_modules/@types/babel__template/node_modules/@babel/types": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.4.tgz",
-      "integrity": "sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.9.tgz",
+      "integrity": "sha512-OwS2CM5KocvQ/k7dFJa8i5bNGJP0hXWfVCfDkqRFP1IreH1JDC7wG6eCYCi0+McbfT8OR/kNqsI0UU0xP9H6PQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -11882,29 +19131,33 @@
       }
     },
     "node_modules/@types/babel__traverse/node_modules/@babel/types": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.4.tgz",
-      "integrity": "sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.9.tgz",
+      "integrity": "sha512-OwS2CM5KocvQ/k7dFJa8i5bNGJP0hXWfVCfDkqRFP1IreH1JDC7wG6eCYCi0+McbfT8OR/kNqsI0UU0xP9H6PQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
       "dev": true
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
+    },
     "node_modules/@types/lodash": {
-      "version": "4.17.7",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.7.tgz",
-      "integrity": "sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==",
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.12.tgz",
+      "integrity": "sha512-sviUmCE8AYdaF/KIHLDJBQgeYzPBI0vf/17NaYehBJfYD1j6/L95Slh07NlyK2iNyBNaEkb3En2jRt+a8y3xZQ==",
       "dev": true
     },
     "node_modules/@types/mute-stream": {
@@ -11917,24 +19170,24 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.16.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.1.tgz",
-      "integrity": "sha512-zJDo7wEadFtSyNz5QITDfRcrhqDvQI1xQNQ0VoizPjM/dVAODqqIUWbJPkvsxmTI0MYRGRikcdjMPhOssnPejQ==",
+      "version": "20.17.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.0.tgz",
+      "integrity": "sha512-a7zRo0f0eLo9K5X9Wp5cAqTUNGzuFLDG2R7C4HY2BhcMAsxgSPuRvAC1ZB6QkuUQXf0YZAgfOX2ZyrBa2n4nHQ==",
       "dev": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
     },
     "node_modules/@types/prop-types": {
-      "version": "15.7.12",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
-      "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
+      "version": "15.7.13",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
+      "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==",
       "devOptional": true
     },
     "node_modules/@types/react": {
-      "version": "18.3.4",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.4.tgz",
-      "integrity": "sha512-J7W30FTdfCxDDjmfRM+/JqLHBIyl7xUIp9kwK637FGmY7+mkSFSe6L4jpZzhj5QMfLssSDP4/i75AKkrdC7/Jw==",
+      "version": "18.3.12",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.12.tgz",
+      "integrity": "sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==",
       "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -11942,9 +19195,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.0",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
-      "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==",
       "dev": true,
       "dependencies": {
         "@types/react": "*"
@@ -12162,14 +19415,14 @@
       "dev": true
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.3.1.tgz",
-      "integrity": "sha512-m/V2syj5CuVnaxcUJOQRel/Wr31FFXRFlnOoq1TVtkCxsY5veGMTEmpWHndrhB2U8ScHtCQB1e+4hWYExQc6Lg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.3.3.tgz",
+      "integrity": "sha512-NooDe9GpHGqNns1i8XDERg0Vsg5SSYRhRxxyTGogUdkdNt47jal+fbuYi+Yfq6pzRCKXyoPcWisfxE6RIM3GKA==",
       "dev": true,
       "dependencies": {
-        "@babel/core": "^7.24.5",
-        "@babel/plugin-transform-react-jsx-self": "^7.24.5",
-        "@babel/plugin-transform-react-jsx-source": "^7.24.1",
+        "@babel/core": "^7.25.2",
+        "@babel/plugin-transform-react-jsx-self": "^7.24.7",
+        "@babel/plugin-transform-react-jsx-source": "^7.24.7",
         "@types/babel__core": "^7.20.5",
         "react-refresh": "^0.14.2"
       },
@@ -12181,12 +19434,12 @@
       }
     },
     "node_modules/@whatwg-node/fetch": {
-      "version": "0.9.21",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.21.tgz",
-      "integrity": "sha512-Wt0jPb+04JjobK0pAAN7mEHxVHcGA9HoP3OyCsZtyAecNQeADXCZ1MihFwVwjsgaRYuGVmNlsCmLxlG6mor8Gw==",
+      "version": "0.9.22",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.22.tgz",
+      "integrity": "sha512-+RIBffgoaRlWV9cKV6wAX71sbeoU2APOI3G13ZRMkabYHwkvDMeZDTyxJcsMXA5CpieJ7NFXF9Xyu72jwvdzqA==",
       "dev": true,
       "dependencies": {
-        "@whatwg-node/node-fetch": "^0.5.23",
+        "@whatwg-node/node-fetch": "^0.5.27",
         "urlpattern-polyfill": "^10.0.0"
       },
       "engines": {
@@ -12194,9 +19447,9 @@
       }
     },
     "node_modules/@whatwg-node/node-fetch": {
-      "version": "0.5.25",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.5.25.tgz",
-      "integrity": "sha512-m6TrxcJlS8ptYLTQL+Ex931RFJsoCQtBQWBNHi5b0xHS0C7FJGUJl1asYZ7MdOhZqdiMVcs1lNJeHsfzyUNjOg==",
+      "version": "0.5.27",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.5.27.tgz",
+      "integrity": "sha512-0OaMj5W4fzWimRSFq07qFiWfquaUMNB+695GwE76LYKVuah+jwCdzSgsIOtwPkiyJ35w0XGhXmJPiIJCdLwopg==",
       "dev": true,
       "dependencies": {
         "@kamilkisiela/fast-url-parser": "^1.1.4",
@@ -12231,9 +19484,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.13.0.tgz",
+      "integrity": "sha512-8zSiw54Oxrdym50NlZ9sUusyO1Z1ZchgRLWRaK6c86XJFClyCgFKetdowBg5bKxyp/u+CDBJG4Mpp0m3HLZl9w==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -12420,24 +19673,24 @@
       }
     },
     "node_modules/aws-amplify": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-6.5.2.tgz",
-      "integrity": "sha512-j5BSkGB19mNIzTuK1q99xjgR80FlwBYrynvqyabeAS7dO1AxqEPbJIB2j8NrjI10dHYktosn0wRLrvZpGRGLBQ==",
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-6.6.6.tgz",
+      "integrity": "sha512-YH04LzQFvhFHDlZjTSayt6LnUQrfXxy3NcESrnjf0BvBTpoHzjxtUBU25/OD7M+RdDHQG0OGTW/4UYYgeqKkhw==",
       "dependencies": {
-        "@aws-amplify/analytics": "7.0.44",
-        "@aws-amplify/api": "6.0.46",
-        "@aws-amplify/auth": "6.3.15",
-        "@aws-amplify/core": "6.3.11",
-        "@aws-amplify/datastore": "5.0.46",
-        "@aws-amplify/notifications": "2.0.44",
-        "@aws-amplify/storage": "6.6.2",
+        "@aws-amplify/analytics": "7.0.53",
+        "@aws-amplify/api": "6.0.55",
+        "@aws-amplify/auth": "6.5.3",
+        "@aws-amplify/core": "6.4.6",
+        "@aws-amplify/datastore": "5.0.55",
+        "@aws-amplify/notifications": "2.0.53",
+        "@aws-amplify/storage": "6.6.11",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.154.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.154.1.tgz",
-      "integrity": "sha512-yJoLTo+fUHRLD4YQMt/QoOPgiT/daci4I5KcaDK8Cx2fWA0Z3h5U9+bWS3ah+8OeZ91fciNCwt6Yt/0p+cp2GQ==",
+      "version": "2.163.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.163.1.tgz",
+      "integrity": "sha512-EBkiWBC3MTnkcYRLBaAPXQoZkzPyB97X21PN/YQUdCmNiz7SJT0F5kQdfKtKsY6RnYsj+pufYMb7n+R07i/t1w==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -12450,9 +19703,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.154.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.154.1.tgz",
-      "integrity": "sha512-XV04/XyNKJ2yyMfYsiSmWx+rIKwTrcrd87p61t4xhE240Iy6Y6LxXVdvkNEOjjbeXVmOUQ7JBG9cW1BeeFiDgg==",
+      "version": "2.163.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.163.1.tgz",
+      "integrity": "sha512-Vw0fMOW6BsdQqIILFfl5qCcmZAJxuLmh1SMBIoQ34k3rUFUmKwUH7PtRXbcHK3N9Sy0WzmF70ys05YqCDdhTSQ==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -12470,17 +19723,17 @@
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "^2.2.202",
         "@aws-cdk/asset-kubectl-v20": "^2.1.2",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.3",
-        "@aws-cdk/cloud-assembly-schema": "^36.0.5",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
+        "@aws-cdk/cloud-assembly-schema": "^38.0.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.2.0",
-        "ignore": "^5.3.1",
+        "ignore": "^5.3.2",
         "jsonschema": "^1.4.1",
         "mime-types": "^2.1.35",
         "minimatch": "^3.1.2",
         "punycode": "^2.3.1",
-        "semver": "^7.6.2",
+        "semver": "^7.6.3",
         "table": "^6.8.2",
         "yaml": "1.10.2"
       },
@@ -12498,15 +19751,15 @@
       "license": "Apache-2.0"
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
-      "version": "8.16.0",
+      "version": "8.17.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.4.1"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -12607,6 +19860,12 @@
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/aws-cdk-lib/node_modules/fast-uri": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
       "version": "11.2.0",
       "dev": true,
@@ -12628,7 +19887,7 @@
       "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
-      "version": "5.3.1",
+      "version": "5.3.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -12730,7 +19989,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.6.2",
+      "version": "7.6.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -12807,15 +20066,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/uri-js": {
-      "version": "4.4.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/yaml": {
@@ -13023,9 +20273,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
-      "integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
+      "version": "4.24.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
+      "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
       "dev": true,
       "funding": [
         {
@@ -13042,10 +20292,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001646",
-        "electron-to-chromium": "^1.5.4",
+        "caniuse-lite": "^1.0.30001669",
+        "electron-to-chromium": "^1.5.41",
         "node-releases": "^2.0.18",
-        "update-browserslist-db": "^1.1.0"
+        "update-browserslist-db": "^1.1.1"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -13159,9 +20409,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001651",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001651.tgz",
-      "integrity": "sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==",
+      "version": "1.0.30001669",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001669.tgz",
+      "integrity": "sha512-DlWzFDJqstqtIVx1zeSpIMLjunf5SmwOw0N2Ck/QSQdS8PLS4+9HrLaYei4w8BIAL7IB/UEDu889d8vhCTPA0w==",
       "dev": true,
       "funding": [
         {
@@ -13431,13 +20681,10 @@
       }
     },
     "node_modules/constructs": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.3.0.tgz",
-      "integrity": "sha512-vbK8i3rIb/xwZxSpTjz3SagHn1qq9BChLEfy5Hf6fB3/2eFbrwt2n9kHwQcS0CPTRBesreeAcsJfMq2229FnbQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 16.14.0"
-      }
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.4.2.tgz",
+      "integrity": "sha512-wsNxBlAott2qg8Zv87q3eYZYgheb9lchtBfjHzzLHtXbttwSrHPs1NNQbBrmbb1YZvYg2+Vh0Dor76w4mFxJkA==",
+      "dev": true
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -13598,12 +20845,12 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dev": true,
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -13872,9 +21119,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.13",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.13.tgz",
-      "integrity": "sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q==",
+      "version": "1.5.43",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.43.tgz",
+      "integrity": "sha512-NxnmFBHDl5Sachd2P46O7UJiMaMHMLSofoIWVJq3mj8NJgG0umiSeljAVP9lGzjI0UDLJJ5jjoGjcrB8RSbjLQ==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -13889,9 +21136,9 @@
       "integrity": "sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw=="
     },
     "node_modules/envinfo": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.13.0.tgz",
-      "integrity": "sha512-cvcaMr7KqXVh4nyzGTVqTum+gAiL265x5jUWQIDLq//zOGbW+gSW/C+OWLleY/rs9Qole6AZLMXPbtIFQbqu+Q==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.14.0.tgz",
+      "integrity": "sha512-CO40UI41xDQzhLB1hWyqUKgFhs250pNcGbyGKe1l/e4FSaI/+YE4IMG76GDt0In67WLPACIITC+sOi08x4wIvg==",
       "dev": true,
       "bin": {
         "envinfo": "dist/cli.js"
@@ -14072,9 +21319,9 @@
       }
     },
     "node_modules/escalade": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
-      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -14093,16 +21340,17 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
-      "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
         "@eslint/eslintrc": "^2.1.4",
-        "@eslint/js": "8.57.0",
-        "@humanwhocodes/config-array": "^0.11.14",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "@ungap/structured-clone": "^1.2.0",
@@ -14160,9 +21408,9 @@
       }
     },
     "node_modules/eslint-plugin-react-refresh": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.11.tgz",
-      "integrity": "sha512-wrAKxMbVr8qhXTtIKfXqAn5SAtRZt0aXxe5P23Fh4pUAdC6XEsybGLB8P0PI4j1yYqOgUEUlzKAGDfo7rJOjcw==",
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.13.tgz",
+      "integrity": "sha512-f1EppwrpJRWmqDTyvAyomFVDYRtrS7iTEqv3nokETnMiMzs2SSTmKRTACce4O2p4jYyowiSMvpdwC/RLcMFhuQ==",
       "dev": true,
       "peerDependencies": {
         "eslint": ">=7"
@@ -14793,9 +22041,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.7.6",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.6.tgz",
-      "integrity": "sha512-ZAqrLlu18NbDdRaHq+AKXzAmqIUPswPWKUchfytdAjiRFnCe5ojG2bstg6mRiZabkKfCoL/e98pbBELIV/YCeA==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.8.1.tgz",
+      "integrity": "sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==",
       "dev": true,
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -15877,6 +23125,12 @@
         }
       }
     },
+    "node_modules/knex/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
     "node_modules/knex/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -16173,9 +23427,9 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
     "node_modules/mute-stream": {
@@ -16574,9 +23828,9 @@
       }
     },
     "node_modules/package-json-from-dist": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
-      "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true
     },
     "node_modules/param-case": {
@@ -16778,18 +24032,18 @@
       }
     },
     "node_modules/pg-pool": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.2.tgz",
-      "integrity": "sha512-Htjbg8BlwXqSBQ9V8Vjtc+vzf/6fVUuak/3/XXKA9oxZprwW3IMDQTGHP+KDmVL7rtd+R1QjbnCFPuTHm3G4hg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.7.0.tgz",
+      "integrity": "sha512-ZOBQForurqh4zZWjrgSwwAtzJ7QiRX0ovFkZr2klsen3Nm0aoh33Ls0fzfv3imeH/nw/O27cjdz5kzYJfeGp/g==",
       "dev": true,
       "peerDependencies": {
         "pg": ">=8.0"
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.1.tgz",
-      "integrity": "sha512-jPIlvgoD63hrEuihvIg+tJhoGjUsLPn6poJY9N5CnlPd91c2T18T/9zBtLxZSb1EhYxBRoZJtzScCaWlYLtktg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.7.0.tgz",
+      "integrity": "sha512-hTK/mE36i8fDDhgDFjy6xNOG+LCorxLG3WO17tku+ij6sVHXh1jQUJ8hYAnRhNla4QVD2H8er/FOjc/+EgC6yQ==",
       "dev": true
     },
     "node_modules/pg-types": {
@@ -16809,9 +24063,9 @@
       }
     },
     "node_modules/pg/node_modules/pg-connection-string": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.4.tgz",
-      "integrity": "sha512-v+Z7W/0EO707aNMaAEfiGnGL9sxxumwLl2fJvCQtMn9Fxsg+lPpPkdcyBSv/KFgpGdYkMfn+EI1Or2EHjpgLCA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.7.0.tgz",
+      "integrity": "sha512-PI2W9mv53rXJQEOb8xNR8lH7Hr+EKa6oJa38zsK0S/ky2er16ios1wLKhZyxzD7jUReiWokc9WK5nxSnC7W1TA==",
       "dev": true
     },
     "node_modules/pgpass": {
@@ -16824,9 +24078,9 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true
     },
     "node_modules/picomatch": {
@@ -16868,9 +24122,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.41",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.41.tgz",
-      "integrity": "sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==",
+      "version": "8.4.47",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
+      "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
       "dev": true,
       "funding": [
         {
@@ -16888,8 +24142,8 @@
       ],
       "dependencies": {
         "nanoid": "^3.3.7",
-        "picocolors": "^1.0.1",
-        "source-map-js": "^1.2.0"
+        "picocolors": "^1.1.0",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -17157,9 +24411,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.52.2",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.52.2.tgz",
-      "integrity": "sha512-pqfPEbERnxxiNMPd0bzmt1tuaPcVccywFDpyk2uV5xCIBphHV5T8SVnX9/o3kplPE1zzKt77+YIoq+EMwJp56A==",
+      "version": "7.53.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.53.1.tgz",
+      "integrity": "sha512-6aiQeBda4zjcuaugWvim9WsGqisoUk+etmFEsSUMm451/Ic8L/UAb7sRtMj3V+Hdzm6mMjU1VhiSzYUZeBm0Vg==",
       "engines": {
         "node": ">=18.0.0"
       },
@@ -17265,15 +24519,15 @@
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
-      "integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.3.tgz",
+      "integrity": "sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.6",
+        "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
         "es-errors": "^1.3.0",
-        "set-function-name": "^2.0.1"
+        "set-function-name": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -17466,12 +24720,12 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.22.4.tgz",
-      "integrity": "sha512-vD8HJ5raRcWOyymsR6Z3o6+RzfEPCnVLMFJ6vRslO1jt4LO6dUo5Qnpg7y4RkZFM2DMe3WUirkI5c16onjrc6A==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.24.0.tgz",
+      "integrity": "sha512-DOmrlGSXNk1DM0ljiQA+i+o0rSLhtii1je5wgk60j49d1jHT5YYttBv1iWOnYSTG+fZZESUOSNiAl89SIet+Cg==",
       "dev": true,
       "dependencies": {
-        "@types/estree": "1.0.5"
+        "@types/estree": "1.0.6"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -17481,22 +24735,22 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.22.4",
-        "@rollup/rollup-android-arm64": "4.22.4",
-        "@rollup/rollup-darwin-arm64": "4.22.4",
-        "@rollup/rollup-darwin-x64": "4.22.4",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.22.4",
-        "@rollup/rollup-linux-arm-musleabihf": "4.22.4",
-        "@rollup/rollup-linux-arm64-gnu": "4.22.4",
-        "@rollup/rollup-linux-arm64-musl": "4.22.4",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.22.4",
-        "@rollup/rollup-linux-riscv64-gnu": "4.22.4",
-        "@rollup/rollup-linux-s390x-gnu": "4.22.4",
-        "@rollup/rollup-linux-x64-gnu": "4.22.4",
-        "@rollup/rollup-linux-x64-musl": "4.22.4",
-        "@rollup/rollup-win32-arm64-msvc": "4.22.4",
-        "@rollup/rollup-win32-ia32-msvc": "4.22.4",
-        "@rollup/rollup-win32-x64-msvc": "4.22.4",
+        "@rollup/rollup-android-arm-eabi": "4.24.0",
+        "@rollup/rollup-android-arm64": "4.24.0",
+        "@rollup/rollup-darwin-arm64": "4.24.0",
+        "@rollup/rollup-darwin-x64": "4.24.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.24.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.24.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.24.0",
+        "@rollup/rollup-linux-arm64-musl": "4.24.0",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.24.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.24.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.24.0",
+        "@rollup/rollup-linux-x64-gnu": "4.24.0",
+        "@rollup/rollup-linux-x64-musl": "4.24.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.24.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.24.0",
+        "@rollup/rollup-win32-x64-msvc": "4.24.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -17875,9 +25129,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -17977,9 +25231,9 @@
       "dev": true
     },
     "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -18271,14 +25525,14 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
+      "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA=="
     },
     "node_modules/tsx": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.17.0.tgz",
-      "integrity": "sha512-eN4mnDA5UMKDt4YZixo9tBioibaMBpoxBkD+rIPAjVmYERSG0/dWEY1CEFuV89CgASlKL499q8AhmkMnnjtOJg==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.1.tgz",
+      "integrity": "sha512-0flMz1lh74BR4wOvBjuh9olbnwqCPc35OOlfyzHba0Dc+QNUeWX/Gq2YTbnwcWPO3BMd8fkzRVrHcsR+a7z7rA==",
       "dev": true,
       "dependencies": {
         "esbuild": "~0.23.0",
@@ -18813,9 +26067,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -18826,9 +26080,9 @@
       }
     },
     "node_modules/ua-parser-js": {
-      "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.38.tgz",
-      "integrity": "sha512-Aq5ppTOfvrCMgAPneW1HfWj66Xi7XL+/mIy996R1/CLS/rcyJQm6QZdsKrUeivDFQ+Oc9Wyuwor8Ze8peEoUoQ==",
+      "version": "1.0.39",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.39.tgz",
+      "integrity": "sha512-k24RCVWlEcjkdOxYmVJgeD/0a1TiSpqLg+ZalVGV9lsnr4yqu0w7tX/x2xX6G4zpkgQnRf89lxuZ1wsbjXM8lw==",
       "dev": true,
       "funding": [
         {
@@ -18844,14 +26098,17 @@
           "url": "https://github.com/sponsors/faisalman"
         }
       ],
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
       "engines": {
         "node": "*"
       }
     },
     "node_modules/uglify-js": {
-      "version": "3.19.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.2.tgz",
-      "integrity": "sha512-S8KA6DDI47nQXJSi2ctQ629YzwOVs+bQML6DAtvy0wgNdpi+0ySpQK0g2pxBq2xfF2z3YCscu7NNA8nXT9PlIQ==",
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
       "dev": true,
       "optional": true,
       "bin": {
@@ -18918,9 +26175,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
-      "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
+      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
       "dev": true,
       "funding": [
         {
@@ -18937,8 +26194,8 @@
         }
       ],
       "dependencies": {
-        "escalade": "^3.1.2",
-        "picocolors": "^1.0.1"
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.0"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -19064,13 +26321,13 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.2.tgz",
-      "integrity": "sha512-dDrQTRHp5C1fTFzcSaMxjk6vdpKvT+2/mIdE07Gw2ykehT49O0z/VHS3zZ8iV/Gh8BJJKHWOe5RjaNrW5xf/GA==",
+      "version": "5.4.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.10.tgz",
+      "integrity": "sha512-1hvaPshuPUtxeQ0hsVH3Mud0ZanOLwVTneA1EgbAM5LhaZEqyPWGRQ7BtaMvUrTDeEaC8pxtj6a6jku3x4z6SQ==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.21.3",
-        "postcss": "^8.4.41",
+        "postcss": "^8.4.43",
         "rollup": "^4.20.0"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -10,14 +10,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@aws-amplify/ui-react": "^6.2.0",
-    "aws-amplify": "^6.5.2",
+    "@aws-amplify/ui-react": "^6.5.5",
+    "aws-amplify": "^6.6.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@aws-amplify/backend": "^1.1.1",
-    "@aws-amplify/backend-cli": "^1.2.4",
+    "@aws-amplify/backend": "^1.5.0",
+    "@aws-amplify/backend-cli": "^1.2.9",
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
     "@typescript-eslint/eslint-plugin": "^7.2.0",
@@ -32,6 +32,6 @@
     "eslint-plugin-react-refresh": "^0.4.6",
     "tsx": "^4.7.2",
     "typescript": "^5.4.5",
-    "vite": "^5.2.0"
+    "vite": "^5.4.10"
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Upgrade Amplify packages to latest. Also, updated `vite` to latest to address these dependabot alerts: https://github.com/aws-samples/amplify-vite-react-template/security/dependabot.

Tested a production build locally via `npm run build`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.